### PR TITLE
Add a helper map useful for constructing a json response

### DIFF
--- a/helper/map.go
+++ b/helper/map.go
@@ -1,0 +1,5 @@
+package helper
+
+// Map is an alias to map[string]interface{}
+// Useful and a cleaner way to create a JSON response object
+type Map map[string]interface{}


### PR DESCRIPTION
## Description

I have added an alias to map[string]interface{} in the helper package.

This is useful when you want to create a long nested json response in the response.JSON function

If your pull request is functional (new utilities, helpers or middleware for example), **include some usage examples**.
For example:

Normally you would write the response as follows:
``` golang
response.JSON(200, map[string]interface{}{
		"name": "Albert Shirima",
		"website": "albertshirima.com",
		"projects": []map[string]interface{}{
			{
				"name": "Goyave",
				"is_contributor": true,
				"meta": map[string]interface{}{
					"website": "goyave.dev",
					"contributors": 2,
				},
			},
		},
	})

```


With the helper struct:
``` golang
response.JSON(200, helper.Map{
    "name": "Albert Shirima",
    "website": "albertshirima.com",
    "projects": []helper.Map{
	    {
		    "name": "Goyave",
		    "is_contributor": true,
		    "meta": helper.Map{
			    "website": "goyave.dev",
			    "contributors": 2,
		    },
	    },
    },
})
```

### Possible drawbacks

None

## Related issue(s)

List all related issues here:

None


