### PR TITLE
Bug/validation order

### DIFF
--- a/validation/validator.go
+++ b/validation/validator.go
@@ -47,6 +47,14 @@ type RuleDefinition struct {
 	// depending on the type.
 	// The language entry used will be "validation.rules.rulename.type"
 	IsTypeDependent bool
+
+	// ComparesFields is true when the rule compares the value of the field under
+	// validation with another field. A field containing at least one rule with
+	// ComparesFields = true will be executed later in the validation process to
+	// ensure conversions are properly executed prior.
+	ComparesFields bool
+
+	// TODO handle objects notation for field comparison
 }
 
 // RuleSet is a request rules definition. Each entry is a field in the request.
@@ -216,12 +224,7 @@ func (r *Rules) sortKeys() {
 		fieldName1 := r.sortedKeys[i]
 		field2 := r.Fields[r.sortedKeys[j]]
 		for _, r := range field2.Rules {
-			switch r.Name {
-			case "after", "before",
-				"greater_than", "greater_than_equal",
-				"lower_than", "lower_than_equal",
-				"in_array", "not_in_array":
-				// TODO doesn't support custom validation rules
+			if validationRules[r.Name].ComparesFields {
 				if r.Params[0] == fieldName1 {
 					return true
 				}
@@ -238,59 +241,59 @@ var validationRules map[string]*RuleDefinition
 
 func init() {
 	validationRules = map[string]*RuleDefinition{
-		"required":           {validateRequired, 0, false, false},
-		"numeric":            {validateNumeric, 0, true, false},
-		"integer":            {validateInteger, 0, true, false},
-		"min":                {validateMin, 1, false, true},
-		"max":                {validateMax, 1, false, true},
-		"between":            {validateBetween, 2, false, true},
-		"greater_than":       {validateGreaterThan, 1, false, true},
-		"greater_than_equal": {validateGreaterThanEqual, 1, false, true},
-		"lower_than":         {validateLowerThan, 1, false, true},
-		"lower_than_equal":   {validateLowerThanEqual, 1, false, true},
-		"string":             {validateString, 0, true, false},
-		"array":              {validateArray, 0, false, false},
-		"distinct":           {validateDistinct, 0, false, false},
-		"digits":             {validateDigits, 0, false, false},
-		"regex":              {validateRegex, 1, false, false},
-		"email":              {validateEmail, 0, false, false},
-		"size":               {validateSize, 1, false, true},
-		"alpha":              {validateAlpha, 0, false, false},
-		"alpha_dash":         {validateAlphaDash, 0, false, false},
-		"alpha_num":          {validateAlphaNumeric, 0, false, false},
-		"starts_with":        {validateStartsWith, 1, false, false},
-		"ends_with":          {validateEndsWith, 1, false, false},
-		"in":                 {validateIn, 1, false, false},
-		"not_in":             {validateNotIn, 1, false, false},
-		"in_array":           {validateInArray, 1, false, false},
-		"not_in_array":       {validateNotInArray, 1, false, false},
-		"timezone":           {validateTimezone, 0, true, false},
-		"ip":                 {validateIP, 0, true, false},
-		"ipv4":               {validateIPv4, 0, true, false},
-		"ipv6":               {validateIPv6, 0, true, false},
-		"json":               {validateJSON, 0, true, false},
-		"url":                {validateURL, 0, true, false},
-		"uuid":               {validateUUID, 0, true, false},
-		"bool":               {validateBool, 0, true, false},
-		"same":               {validateSame, 1, false, false},
-		"different":          {validateDifferent, 1, false, false},
-		"confirmed":          {validateConfirmed, 0, false, false},
-		"file":               {validateFile, 0, false, false},
-		"mime":               {validateMIME, 1, false, false},
-		"image":              {validateImage, 0, false, false},
-		"extension":          {validateExtension, 1, false, false},
-		"count":              {validateCount, 1, false, false},
-		"count_min":          {validateCountMin, 1, false, false},
-		"count_max":          {validateCountMax, 1, false, false},
-		"count_between":      {validateCountBetween, 2, false, false},
-		"date":               {validateDate, 0, true, false},
-		"before":             {validateBefore, 1, false, false},
-		"before_equal":       {validateBeforeEqual, 1, false, false},
-		"after":              {validateAfter, 1, false, false},
-		"after_equal":        {validateAfterEqual, 1, false, false},
-		"date_equals":        {validateDateEquals, 1, false, false},
-		"date_between":       {validateDateBetween, 2, false, false},
-		"object":             {validateObject, 0, true, false},
+		"required":           {validateRequired, 0, false, false, false},
+		"numeric":            {validateNumeric, 0, true, false, false},
+		"integer":            {validateInteger, 0, true, false, false},
+		"min":                {validateMin, 1, false, true, false},
+		"max":                {validateMax, 1, false, true, false},
+		"between":            {validateBetween, 2, false, true, false},
+		"greater_than":       {validateGreaterThan, 1, false, true, true},
+		"greater_than_equal": {validateGreaterThanEqual, 1, false, true, true},
+		"lower_than":         {validateLowerThan, 1, false, true, true},
+		"lower_than_equal":   {validateLowerThanEqual, 1, false, true, true},
+		"string":             {validateString, 0, true, false, false},
+		"array":              {validateArray, 0, false, false, false},
+		"distinct":           {validateDistinct, 0, false, false, false},
+		"digits":             {validateDigits, 0, false, false, false},
+		"regex":              {validateRegex, 1, false, false, false},
+		"email":              {validateEmail, 0, false, false, false},
+		"size":               {validateSize, 1, false, true, false},
+		"alpha":              {validateAlpha, 0, false, false, false},
+		"alpha_dash":         {validateAlphaDash, 0, false, false, false},
+		"alpha_num":          {validateAlphaNumeric, 0, false, false, false},
+		"starts_with":        {validateStartsWith, 1, false, false, false},
+		"ends_with":          {validateEndsWith, 1, false, false, false},
+		"in":                 {validateIn, 1, false, false, false},
+		"not_in":             {validateNotIn, 1, false, false, false},
+		"in_array":           {validateInArray, 1, false, false, true},
+		"not_in_array":       {validateNotInArray, 1, false, false, true},
+		"timezone":           {validateTimezone, 0, true, false, false},
+		"ip":                 {validateIP, 0, true, false, false},
+		"ipv4":               {validateIPv4, 0, true, false, false},
+		"ipv6":               {validateIPv6, 0, true, false, false},
+		"json":               {validateJSON, 0, true, false, false},
+		"url":                {validateURL, 0, true, false, false},
+		"uuid":               {validateUUID, 0, true, false, false},
+		"bool":               {validateBool, 0, true, false, false},
+		"same":               {validateSame, 1, false, false, true},
+		"different":          {validateDifferent, 1, false, false, true},
+		"confirmed":          {validateConfirmed, 0, false, false, true},
+		"file":               {validateFile, 0, false, false, false},
+		"mime":               {validateMIME, 1, false, false, false},
+		"image":              {validateImage, 0, false, false, false},
+		"extension":          {validateExtension, 1, false, false, false},
+		"count":              {validateCount, 1, false, false, false},
+		"count_min":          {validateCountMin, 1, false, false, false},
+		"count_max":          {validateCountMax, 1, false, false, false},
+		"count_between":      {validateCountBetween, 2, false, false, false},
+		"date":               {validateDate, 0, true, false, false},
+		"before":             {validateBefore, 1, false, false, true},
+		"before_equal":       {validateBeforeEqual, 1, false, false, true},
+		"after":              {validateAfter, 1, false, false, true},
+		"after_equal":        {validateAfterEqual, 1, false, false, true},
+		"date_equals":        {validateDateEquals, 1, false, false, true},
+		"date_between":       {validateDateBetween, 2, false, false, true},
+		"object":             {validateObject, 0, true, false, false},
 	}
 }
 

--- a/validation/validator.go
+++ b/validation/validator.go
@@ -276,7 +276,7 @@ func init() {
 		"bool":               {validateBool, 0, true, false, false},
 		"same":               {validateSame, 1, false, false, true},
 		"different":          {validateDifferent, 1, false, false, true},
-		"confirmed":          {validateConfirmed, 0, false, false, true},
+		"confirmed":          {validateConfirmed, 0, false, false, false},
 		"file":               {validateFile, 0, false, false, false},
 		"mime":               {validateMIME, 1, false, false, false},
 		"image":              {validateImage, 0, false, false, false},

--- a/validation/validator.go
+++ b/validation/validator.go
@@ -226,6 +226,7 @@ func (r *Rules) sortKeys() {
 		for _, r := range field2.Rules {
 			if validationRules[r.Name].ComparesFields {
 				if r.Params[0] == fieldName1 {
+					// FIXME what if rule has multiple fields in parameters
 					return true
 				}
 			}

--- a/validation/validator.go
+++ b/validation/validator.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"goyave.dev/goyave/v3/helper"
 	"goyave.dev/goyave/v3/lang"
 )
 
@@ -224,11 +225,8 @@ func (r *Rules) sortKeys() {
 		fieldName1 := r.sortedKeys[i]
 		field2 := r.Fields[r.sortedKeys[j]]
 		for _, r := range field2.Rules {
-			if validationRules[r.Name].ComparesFields {
-				if r.Params[0] == fieldName1 {
-					// FIXME what if rule has multiple fields in parameters
-					return true
-				}
+			if validationRules[r.Name].ComparesFields && helper.ContainsStr(r.Params, fieldName1) {
+				return true
 			}
 		}
 		return false

--- a/validation/validator_test.go
+++ b/validation/validator_test.go
@@ -661,7 +661,9 @@ func (suite *ValidatorTestSuite) TestParseRuleSet() {
 	suite.Len(rules.Fields["number"].Rules, 1)
 	suite.Equal(&Rule{Name: "numeric", Params: []string{}, ArrayDimension: 0}, rules.Fields["number"].Rules[0])
 
-	suite.Equal(rules, set.AsRules())
+	parsed := set.AsRules()
+	suite.Equal(rules.Fields, parsed.Fields)
+	suite.Equal(rules.checked, parsed.checked)
 
 	suite.True(rules.checked)
 	// Resulting Rules should be checked after parsing

--- a/validation/validator_test.go
+++ b/validation/validator_test.go
@@ -905,10 +905,6 @@ func (suite *ValidatorTestSuite) TestSortKeys() {
 	suite.Contains(rules.sortedKeys, "mid")
 	suite.Contains(rules.sortedKeys, "end")
 	suite.Contains(rules.sortedKeys, "text")
-
-	// TODO test objects
-	// TODO test conversion rules
-	// TODO test other comparison rules
 }
 
 func (suite *ValidatorTestSuite) TestSortKeysIncoherent() {
@@ -963,6 +959,41 @@ func (suite *ValidatorTestSuite) TestSortKeysMultipleComparedFields() {
 	suite.Contains(rules.sortedKeys, "mid")
 	suite.Contains(rules.sortedKeys, "end")
 	suite.Contains(rules.sortedKeys, "text")
+}
+
+func (suite *ValidatorTestSuite) TestSortKeysBuiltinRules() {
+	// Tests that all rules that are supposed to be comparing fields
+	// are sorted correctly.
+	suite.testSortKeysWithRule("greater_than")
+	suite.testSortKeysWithRule("greater_than_equal")
+	suite.testSortKeysWithRule("lower_than")
+	suite.testSortKeysWithRule("lower_than_equal")
+	suite.testSortKeysWithRule("in_array")
+	suite.testSortKeysWithRule("not_in_array")
+	suite.testSortKeysWithRule("same")
+	suite.testSortKeysWithRule("different")
+	suite.testSortKeysWithRule("before")
+	suite.testSortKeysWithRule("before_equal")
+	suite.testSortKeysWithRule("after")
+	suite.testSortKeysWithRule("after_equal")
+	suite.testSortKeysWithRule("date_equals")
+	suite.testSortKeysWithRule("date_between")
+}
+
+func (suite *ValidatorTestSuite) testSortKeysWithRule(rule string) {
+	rules := &Rules{
+		Fields: map[string]*Field{
+			"one": {Rules: []*Rule{
+				{Name: "string"},
+				{Name: rule, Params: []string{"two"}},
+			}},
+			"two": {Rules: []*Rule{
+				{Name: "string"},
+			}},
+		},
+	}
+	rules.sortKeys()
+	suite.Equal([]string{"two", "one"}, rules.sortedKeys)
 }
 
 func TestValidatorTestSuite(t *testing.T) {

--- a/validation/validator_test.go
+++ b/validation/validator_test.go
@@ -932,6 +932,39 @@ func (suite *ValidatorTestSuite) TestSortKeysIncoherent() {
 	suite.Contains(rules.sortedKeys, "end")
 }
 
+func (suite *ValidatorTestSuite) TestSortKeysMultipleComparedFields() {
+	rules := &Rules{
+		Fields: map[string]*Field{
+			"text": {Rules: []*Rule{
+				{Name: "string"},
+			}},
+			"mid": {Rules: []*Rule{
+				{Name: "date"},
+				{Name: "after", Params: []string{"start"}},
+				{Name: "before", Params: []string{"end"}},
+			}},
+			"end": {Rules: []*Rule{
+				{Name: "date"},
+				{Name: "date_between", Params: []string{"start", "end"}},
+			}},
+			"start": {Rules: []*Rule{
+				{Name: "date"},
+			}},
+		},
+	}
+	rules.sortKeys()
+	indexStart := helper.IndexOfStr(rules.sortedKeys, "start")
+	indexEnd := helper.IndexOfStr(rules.sortedKeys, "end")
+	indexMid := helper.IndexOfStr(rules.sortedKeys, "mid")
+	suite.Greater(indexEnd, indexStart)
+	suite.Greater(indexMid, indexStart)
+	suite.Greater(indexMid, indexEnd)
+	suite.Contains(rules.sortedKeys, "start")
+	suite.Contains(rules.sortedKeys, "mid")
+	suite.Contains(rules.sortedKeys, "end")
+	suite.Contains(rules.sortedKeys, "text")
+}
+
 func TestValidatorTestSuite(t *testing.T) {
 	suite.Run(t, new(ValidatorTestSuite))
 }


### PR DESCRIPTION
## Description

Fixes #144 by sorting `validation.FieldMap` keys to ensure compared fields are validated in the correct order. This change also adds `RuleDefinition.ComparesFields` to identify rules that are important in this sorting process.

### Possible drawbacks

Slightly slower boot time, because keys are sorted at startup. This has no impact on performance once the application has started. 

## Related issue(s)

* #144

## Additional information

Custom rules that are comparing fields *should* update their rule definition to avoid the issue fixed by this PR.
