### PR TITLE
Allow to set the entries of gorm.Config{}, from the config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,6 +727,7 @@ A big "Thank you" to the Goyave contributors:
 - [Guillermo Galvan](https://github.com/gmgalvan) (Request extra data)
 - [Albert Shirima](https://github.com/agbaraka) (Rate limiting)
 - [Łukasz Sowa](https://github.com/Morishiri) (Custom claims in JWT)
+- [Zao SOULA](https://github.com/zaosoula) (Custom GORM.Config{} in config file)
 
 ## License
 

--- a/config.test.json
+++ b/config.test.json
@@ -25,7 +25,16 @@
         "maxOpenConnections": 20,
         "maxIdleConnections": 20,
         "maxLifetime": 300,
-        "autoMigrate": false
+        "autoMigrate": false,
+        "config": {
+            "skipDefaultTransaction": false,
+            "dryRun": false,
+            "prepareStmt": true,
+            "disableNestedTransaction": false,
+            "allowGlobalUpdate": false,
+            "disableAutomaticPing": false,
+            "disableForeignKeyConstraintWhenMigrating": false
+        }
     },
     "auth": {
         "jwt": {

--- a/config/config.go
+++ b/config/config.go
@@ -64,7 +64,6 @@ var configDefaults object = object{
 		"autoMigrate":        &Entry{false, []interface{}{}, reflect.Bool, false},
 		"config": object{
 			"skipDefaultTransaction":                   &Entry{false, []interface{}{}, reflect.Bool, false},
-			"namingStrategy":                           &Entry{false, []interface{}{}, reflect.Bool, false},
 			"dryRun":                                   &Entry{false, []interface{}{}, reflect.Bool, false},
 			"prepareStmt":                              &Entry{true, []interface{}{}, reflect.Bool, false},
 			"disableNestedTransaction":                 &Entry{false, []interface{}{}, reflect.Bool, false},

--- a/config/config.go
+++ b/config/config.go
@@ -62,6 +62,16 @@ var configDefaults object = object{
 		"maxIdleConnections": &Entry{20, []interface{}{}, reflect.Int, false},
 		"maxLifetime":        &Entry{300, []interface{}{}, reflect.Int, false},
 		"autoMigrate":        &Entry{false, []interface{}{}, reflect.Bool, false},
+		"config": object{
+			"skipDefaultTransaction":                   &Entry{false, []interface{}{}, reflect.Bool, false},
+			"namingStrategy":                           &Entry{false, []interface{}{}, reflect.Bool, false},
+			"dryRun":                                   &Entry{false, []interface{}{}, reflect.Bool, false},
+			"prepareStmt":                              &Entry{true, []interface{}{}, reflect.Bool, false},
+			"disableNestedTransaction":                 &Entry{false, []interface{}{}, reflect.Bool, false},
+			"allowGlobalUpdate":                        &Entry{false, []interface{}{}, reflect.Bool, false},
+			"disableAutomaticPing":                     &Entry{false, []interface{}{}, reflect.Bool, false},
+			"disableForeignKeyConstraintWhenMigrating": &Entry{false, []interface{}{}, reflect.Bool, false},
+		},
 	},
 }
 

--- a/database/config.test.json
+++ b/database/config.test.json
@@ -14,6 +14,15 @@
         "maxOpenConnections": 20,
         "maxIdleConnections": 20,
         "maxLifetime": 300,
-        "autoMigrate": false
+        "autoMigrate": false,
+        "config": {
+            "skipDefaultTransaction": false,
+            "dryRun": false,
+            "prepareStmt": true,
+            "disableNestedTransaction": false,
+            "allowGlobalUpdate": false,
+            "disableAutomaticPing": false,
+            "disableForeignKeyConstraintWhenMigrating": false
+        }
     }
 }

--- a/database/database.go
+++ b/database/database.go
@@ -166,8 +166,14 @@ func newConnection() *gorm.DB {
 
 	dsn := dialect.buildDSN()
 	db, err := gorm.Open(dialect.initializer(dsn), &gorm.Config{
-		PrepareStmt: true,
-		Logger:      logger.Default.LogMode(logLevel),
+		Logger:                                   logger.Default.LogMode(logLevel),
+		SkipDefaultTransaction:                   config.GetBool("database.config.skipDefaultTransaction"),
+		DryRun:                                   config.GetBool("database.config.dryRun"),
+		PrepareStmt:                              config.GetBool("database.config.prepareStmt"),
+		DisableNestedTransaction:                 config.GetBool("database.config.disableNestedTransaction"),
+		AllowGlobalUpdate:                        config.GetBool("database.config.allowGlobalUpdate"),
+		DisableAutomaticPing:                     config.GetBool("database.config.disableAutomaticPing"),
+		DisableForeignKeyConstraintWhenMigrating: config.GetBool("database.config.disableForeignKeyConstraintWhenMigrating"),
 	})
 	if err != nil {
 		panic(err)

--- a/resources/config.migration-test.json
+++ b/resources/config.migration-test.json
@@ -25,7 +25,16 @@
         "maxOpenConnections": 20,
         "maxIdleConnections": 20,
         "maxLifetime": 300,
-        "autoMigrate": true
+        "autoMigrate": true,
+        "config": {
+            "skipDefaultTransaction": false,
+            "dryRun": false,
+            "prepareStmt": true,
+            "disableNestedTransaction": false,
+            "allowGlobalUpdate": false,
+            "disableAutomaticPing": false,
+            "disableForeignKeyConstraintWhenMigrating": false
+        }
     },
     "auth": {
         "jwt": {


### PR DESCRIPTION
## Description

Allow to set the entries of gorm.Config{}, from the config file.

### Usage examples
(#147)  *Unable to set DisableForeignKeyConstraintWhenMigrating:*
As SQLite do not support constraints, when using associations in GORM models we get the following error
```
panic: constraints not implemented on sqlite, consider using DisableForeignKeyConstraintWhenMigrating, more details https://github.com/go-gorm/gorm/wiki/GORM-V2-Release-Note-Draft#all-new-migrator
```
To solve it we can modify our database config, by setting ``database.config.disableForeignKeyConstraintWhenMigrating`` to ``true`` :
```json
...
"database": {
        "connection": "sqlite3",
        "name": "dev.db",
        "autoMigrate": true,
        "config": {
            "disableForeignKeyConstraintWhenMigrating": true
        }
    },
...
```

### Possible drawbacks
 
None
## Related issue(s)

List all related issues here:

* #147