### PR TITLE
Remove name parameter in Cookies method

### DIFF
--- a/request.go
+++ b/request.go
@@ -95,7 +95,7 @@ func (r *Request) RemoteAddress() string {
 }
 
 // Cookies returns the HTTP cookies sent with the request.
-func (r *Request) Cookies(name string) []*http.Cookie {
+func (r *Request) Cookies() []*http.Cookie {
 	if r.cookies == nil {
 		r.cookies = r.httpRequest.Cookies()
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -79,8 +79,9 @@ func TestRequestCookies(t *testing.T) {
 		Value: "test",
 	})
 	request := createTestRequest(rawRequest)
-	cookies := request.Cookies("cookie-name")
+	cookies := request.Cookies()
 	assert.Equal(t, 1, len(cookies))
+	assert.Equal(t, "cookie-name", cookies[0].Name)
 	assert.Equal(t, "test", cookies[0].Value)
 }
 


### PR DESCRIPTION
The name parameter is unused inside the method

## Description

Name parameter in the Cookies method signature is unused.

### Possible drawbacks

Introduces breaking changes
