### PR TITLE
v4.4.2

### DIFF
--- a/validation/rules.go
+++ b/validation/rules.go
@@ -330,5 +330,10 @@ func validateSize(ctx *Context) bool {
 
 func validateObject(ctx *Context) bool {
 	_, ok := ctx.Value.(map[string]interface{})
+	if !ok {
+		if validateJSON(ctx) {
+			_, ok = ctx.Value.(map[string]interface{})
+		}
+	}
 	return ok
 }

--- a/validation/rules_test.go
+++ b/validation/rules_test.go
@@ -594,4 +594,8 @@ func TestValidateSize(t *testing.T) {
 func TestValidateObject(t *testing.T) {
 	assert.False(t, validateObject(newTestContext("field", "123", []string{}, map[string]interface{}{})))
 	assert.True(t, validateObject(newTestContext("field", map[string]interface{}{"hello": "world"}, []string{}, map[string]interface{}{})))
+
+	// From a JSON string
+	assert.False(t, validateObject(newTestContext("field", "[1,2,3]", []string{}, map[string]interface{}{})))
+	assert.True(t, validateObject(newTestContext("field", `{"hello": "world"}`, []string{}, map[string]interface{}{})))
 }


### PR DESCRIPTION
## Description

- "object" validation rule now also accepts JSON strings. This is useful when you expect an object but the field is given via a query param.

### Possible drawbacks

None

## Related issue(s)

None
