### PR TITLE
fixed interface compatibility issues with testify v1.8.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/imdario/mergo v0.3.13
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.2
 	golang.org/x/crypto v0.4.0
 	gorm.io/driver/mysql v1.4.4
 	gorm.io/driver/postgres v1.4.5

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/testsuite.go
+++ b/testsuite.go
@@ -22,6 +22,7 @@ import (
 	"goyave.dev/goyave/v4/util/fsutil"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 	testify "github.com/stretchr/testify/suite"
 	"goyave.dev/goyave/v4/config"
 	"goyave.dev/goyave/v4/lang"
@@ -44,6 +45,7 @@ type ITestSuite interface {
 
 	T() *testing.T
 	SetT(*testing.T)
+	SetS(suite suite.TestingSuite)
 
 	GetBody(*http.Response) []byte
 	GetJSONBody(*http.Response, interface{}) error


### PR DESCRIPTION
## Description

This PR updates the `ITestSuite interface` to be compatible with the next version of testify `v1.8.2` which adds a method to its `TestingSuite interface` which this mimics. Without this change, packages that depend on the newer testify library will cause a conflict at build time.

### Possible drawbacks

None. Since this interface is used internally, it should not impact other packages that depend on either testify version.

## Related issue(s)

None