### PR TITLE
#213 - Validation: use default language if no language is given in options

### DIFF
--- a/validation/validator.go
+++ b/validation/validator.go
@@ -275,6 +275,9 @@ func Validate(options *Options) (*Errors, []error) {
 	if options.Extra == nil {
 		options.Extra = map[any]any{}
 	}
+	if options.Language == nil {
+		options.Language = lang.New().GetDefault()
+	}
 
 	rules := options.Rules.AsRules()
 	for _, field := range rules {

--- a/validation/validator_test.go
+++ b/validation/validator_test.go
@@ -283,6 +283,23 @@ func TestValidate(t *testing.T) {
 			wantData: map[string]any{},
 		},
 		{
+			desc: "nil_delete_from_parent_without_language",
+			options: &Options{
+				Data: map[string]any{"property": nil},
+				Rules: RuleSet{
+					{Path: "property", Rules: List{Required()}},
+				},
+			},
+			wantValidationErrors: &Errors{
+				Fields: FieldsErrors{
+					"property": &Errors{
+						Errors: []string{"The property is required."},
+					},
+				},
+			},
+			wantData: map[string]any{},
+		},
+		{
 			desc: "nil_nullable_dont_delete_from_parent",
 			options: &Options{
 				Data:     map[string]any{"property": nil},


### PR DESCRIPTION
Fetch default language if no language is given when validating.

## References

**Issue:** fixes #213 

## Description



### Possible drawbacks



