### PR TITLE
#216 - Add message to request (extra) and handle in status handler

### DIFF
--- a/lang/default.go
+++ b/lang/default.go
@@ -10,7 +10,7 @@ var enUS = &Language{
 		"auth.jwt-invalid":             "Your authentication token is invalid.",
 		"auth.jwt-not-valid-yet":       "Your authentication token is not valid yet.",
 		"auth.jwt-expired":             "Your authentication token is expired.",
-		"request.json-invalid-body":    "The request Content-Type indicates JSON, but the request body is empty or invalid",
+		"parse.json-invalid-body":      "The request Content-Type indicates JSON, but the request body is empty or invalid",
 	},
 	validation: validationLines{
 		rules: map[string]string{

--- a/lang/default.go
+++ b/lang/default.go
@@ -10,7 +10,7 @@ var enUS = &Language{
 		"auth.jwt-invalid":             "Your authentication token is invalid.",
 		"auth.jwt-not-valid-yet":       "Your authentication token is not valid yet.",
 		"auth.jwt-expired":             "Your authentication token is expired.",
-		"request.json-empty-body":      "The request Content-Type indicates JSON, but the request body is empty",
+		"request.json-invalid-body":    "The request Content-Type indicates JSON, but the request body is empty or invalid",
 	},
 	validation: validationLines{
 		rules: map[string]string{

--- a/lang/default.go
+++ b/lang/default.go
@@ -10,6 +10,7 @@ var enUS = &Language{
 		"auth.jwt-invalid":             "Your authentication token is invalid.",
 		"auth.jwt-not-valid-yet":       "Your authentication token is not valid yet.",
 		"auth.jwt-expired":             "Your authentication token is expired.",
+		"request.json-empty-body":      "The request Content-Type indicates JSON, but the request body is empty",
 	},
 	validation: validationLines{
 		rules: map[string]string{

--- a/lang/default.go
+++ b/lang/default.go
@@ -3,14 +3,17 @@ package lang
 var enUS = &Language{
 	name: "en-US",
 	lines: map[string]string{
-		"malformed-request":            "Malformed request",
-		"malformed-json":               "Malformed JSON",
-		"auth.invalid-credentials":     "Invalid credentials.",
-		"auth.no-credentials-provided": "Invalid or missing authentication header.",
-		"auth.jwt-invalid":             "Your authentication token is invalid.",
-		"auth.jwt-not-valid-yet":       "Your authentication token is not valid yet.",
-		"auth.jwt-expired":             "Your authentication token is expired.",
-		"parse.json-invalid-body":      "The request Content-Type indicates JSON, but the request body is empty or invalid",
+		"malformed-request":              "Malformed request",
+		"malformed-json":                 "Malformed JSON",
+		"auth.invalid-credentials":       "Invalid credentials.",
+		"auth.no-credentials-provided":   "Invalid or missing authentication header.",
+		"auth.jwt-invalid":               "Your authentication token is invalid.",
+		"auth.jwt-not-valid-yet":         "Your authentication token is not valid yet.",
+		"auth.jwt-expired":               "Your authentication token is expired.",
+		"parse.invalid-query":            "Failed to parse query string due to invalid syntax or unexpected input format.",
+		"parse.json-invalid-body":        "The request Content-Type indicates JSON, but the request body is empty or invalid.",
+		"parse.invalid-content-for-type": "The request content does not match its type. E.g. invalid multipart/form-data or a problem with the file upload.",
+		"parse.error-in-request-body":    "Failed to read request body due to connection issues, timeouts, size mismatches, or corrupted data.",
 	},
 	validation: validationLines{
 		rules: map[string]string{

--- a/middleware/parse/parse.go
+++ b/middleware/parse/parse.go
@@ -3,7 +3,6 @@ package parse
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -75,7 +74,7 @@ func (m *Middleware) Handle(next goyave.Handler) goyave.Handler {
 					if err := json.Unmarshal(bodyBytes, &body); err != nil {
 						response.Status(http.StatusBadRequest)
 						r.Extra[goyave.ExtraRequestError{}] = []error{
-							fmt.Errorf("request.json-invalid-body"),
+							goyave.ErrInvalidJSONBody,
 						}
 					}
 					r.Data = body

--- a/middleware/parse/parse.go
+++ b/middleware/parse/parse.go
@@ -3,6 +3,7 @@ package parse
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -73,6 +74,9 @@ func (m *Middleware) Handle(next goyave.Handler) goyave.Handler {
 					var body any
 					if err := json.Unmarshal(bodyBytes, &body); err != nil {
 						response.Status(http.StatusBadRequest)
+						r.Extra[goyave.ExtraRequestError{}] = []error{
+							fmt.Errorf("request.json-empty-body"),
+						}
 					}
 					r.Data = body
 				} else {

--- a/middleware/parse/parse.go
+++ b/middleware/parse/parse.go
@@ -75,7 +75,7 @@ func (m *Middleware) Handle(next goyave.Handler) goyave.Handler {
 					if err := json.Unmarshal(bodyBytes, &body); err != nil {
 						response.Status(http.StatusBadRequest)
 						r.Extra[goyave.ExtraRequestError{}] = []error{
-							fmt.Errorf("request.json-empty-body"),
+							fmt.Errorf("request.json-invalid-body"),
 						}
 					}
 					r.Data = body

--- a/middleware/parse/parse.go
+++ b/middleware/parse/parse.go
@@ -47,6 +47,7 @@ func (m *Middleware) Handle(next goyave.Handler) goyave.Handler {
 	return func(response *goyave.Response, r *goyave.Request) {
 		if err := parseQuery(r); err != nil {
 			response.Status(http.StatusBadRequest)
+			r.Extra[goyave.ExtraParseError{}] = fmt.Errorf("%w: %w", goyave.ErrInvalidQuery, err)
 			return
 		}
 
@@ -83,10 +84,12 @@ func (m *Middleware) Handle(next goyave.Handler) goyave.Handler {
 					r.Data, err = generateFlatMap(req, maxSize)
 					if err != nil {
 						response.Status(http.StatusBadRequest)
+						r.Extra[goyave.ExtraParseError{}] = fmt.Errorf("%w: %w", goyave.ErrInvalidContentForType, err)
 					}
 				}
 			} else {
 				response.Status(http.StatusBadRequest)
+				r.Extra[goyave.ExtraParseError{}] = fmt.Errorf("%w: %w", goyave.ErrErrorInRequestBody, err)
 			}
 		}
 

--- a/middleware/parse/parse.go
+++ b/middleware/parse/parse.go
@@ -3,6 +3,7 @@ package parse
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -73,9 +74,7 @@ func (m *Middleware) Handle(next goyave.Handler) goyave.Handler {
 					var body any
 					if err := json.Unmarshal(bodyBytes, &body); err != nil {
 						response.Status(http.StatusBadRequest)
-						r.Extra[goyave.ExtraRequestError{}] = []error{
-							goyave.ErrInvalidJSONBody,
-						}
+						r.Extra[goyave.ExtraParseError{}] = fmt.Errorf("%w: %w", goyave.ErrInvalidJSONBody, err)
 					}
 					r.Data = body
 				} else {

--- a/middleware/parse/parse_test.go
+++ b/middleware/parse/parse_test.go
@@ -192,7 +192,7 @@ func TestParseMiddleware(t *testing.T) {
 		request.Header().Set("Content-Type", writer.FormDataContentType())
 
 		result := server.TestMiddleware(&Middleware{}, request, func(resp *goyave.Response, _ *goyave.Request) {
-			resp.Status(http.StatusBadRequest)
+			resp.Status(http.StatusOK)
 		})
 
 		assert.NoError(t, result.Body.Close())

--- a/middleware/parse/parse_test.go
+++ b/middleware/parse/parse_test.go
@@ -2,7 +2,6 @@ package parse
 
 import (
 	"bytes"
-	"fmt"
 	"mime/multipart"
 	"net/http"
 	"strings"
@@ -109,7 +108,11 @@ func TestParseMiddleware(t *testing.T) {
 		assert.NoError(t, result.Body.Close())
 		assert.Equal(t, http.StatusBadRequest, result.StatusCode)
 		assert.NotNil(t, request.Extra[goyave.ExtraRequestError{}])
-		assert.Contains(t, request.Extra[goyave.ExtraRequestError{}].([]error), fmt.Errorf("request.json-invalid-body"))
+		assert.NotPanics(t, func() {
+			extraErrors, ok := request.Extra[goyave.ExtraRequestError{}].([]error)
+			require.True(t, ok)
+			assert.Contains(t, extraErrors, goyave.ErrInvalidJSONBody)
+		})
 	})
 
 	t.Run("Multipart", func(t *testing.T) {

--- a/middleware/parse/parse_test.go
+++ b/middleware/parse/parse_test.go
@@ -109,7 +109,7 @@ func TestParseMiddleware(t *testing.T) {
 		assert.NoError(t, result.Body.Close())
 		assert.Equal(t, http.StatusBadRequest, result.StatusCode)
 		assert.NotNil(t, request.Extra[goyave.ExtraRequestError{}])
-		assert.Contains(t, request.Extra[goyave.ExtraRequestError{}].([]error), fmt.Errorf("request.json-empty-body"))
+		assert.Contains(t, request.Extra[goyave.ExtraRequestError{}].([]error), fmt.Errorf("request.json-invalid-body"))
 	})
 
 	t.Run("Multipart", func(t *testing.T) {

--- a/middleware/parse/parse_test.go
+++ b/middleware/parse/parse_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"mime/multipart"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -56,6 +57,12 @@ func TestParseMiddleware(t *testing.T) {
 		})
 		assert.NoError(t, result.Body.Close())
 		assert.Equal(t, http.StatusBadRequest, result.StatusCode)
+		assert.NotNil(t, request.Extra[goyave.ExtraParseError{}])
+		assert.NotPanics(t, func() {
+			extraError, ok := request.Extra[goyave.ExtraParseError{}].(error)
+			require.True(t, ok)
+			assert.ErrorIs(t, extraError, goyave.ErrInvalidQuery)
+		})
 	})
 
 	t.Run("Entity Too Large", func(t *testing.T) {
@@ -99,22 +106,44 @@ func TestParseMiddleware(t *testing.T) {
 		assert.Equal(t, http.StatusOK, result.StatusCode)
 	})
 
-	t.Run("JSON Invalid", func(t *testing.T) {
-		request := testutil.NewTestRequest(http.MethodPost, "/parse", bytes.NewBuffer([]byte("{\"unclosed\"")))
-		request.Lang = server.Lang.GetDefault()
-		request.Header().Set("Content-Type", "application/json")
+	t.Run("JSON Parsing Tests", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			body     []byte
+			expected int
+		}{
+			{
+				name:     "JSON Invalid",
+				body:     []byte("{\"unclosed\""),
+				expected: http.StatusBadRequest,
+			},
+			{
+				name:     "JSON Empty",
+				body:     []byte(""),
+				expected: http.StatusBadRequest,
+			},
+		}
 
-		result := server.TestMiddleware(&Middleware{MaxUploadSize: 0.01}, request, func(_ *goyave.Response, _ *goyave.Request) {
-			assert.Fail(t, "Middleware should not pass")
-		})
-		assert.NoError(t, result.Body.Close())
-		assert.Equal(t, http.StatusBadRequest, result.StatusCode)
-		assert.NotNil(t, request.Extra[goyave.ExtraParseError{}])
-		assert.NotPanics(t, func() {
-			extraError, ok := request.Extra[goyave.ExtraParseError{}].(error)
-			require.True(t, ok)
-			assert.Error(t, extraError)
-		})
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				request := testutil.NewTestRequest(http.MethodPost, "/parse", bytes.NewBuffer(tt.body))
+				request.Lang = server.Lang.GetDefault()
+				request.Header().Set("Content-Type", "application/json")
+
+				result := server.TestMiddleware(&Middleware{MaxUploadSize: 0.01}, request, func(_ *goyave.Response, _ *goyave.Request) {
+					assert.Fail(t, "Middleware should not pass")
+				})
+
+				assert.NoError(t, result.Body.Close())
+				assert.Equal(t, tt.expected, result.StatusCode)
+				assert.NotNil(t, request.Extra[goyave.ExtraParseError{}])
+				assert.NotPanics(t, func() {
+					extraError, ok := request.Extra[goyave.ExtraParseError{}].(error)
+					require.True(t, ok)
+					assert.ErrorIs(t, extraError, goyave.ErrInvalidJSONBody)
+				})
+			})
+		}
 	})
 
 	t.Run("Multipart", func(t *testing.T) {
@@ -152,6 +181,72 @@ func TestParseMiddleware(t *testing.T) {
 
 		assert.NoError(t, result.Body.Close())
 		assert.Equal(t, http.StatusOK, result.StatusCode)
+	})
+
+	t.Run("Invalid Multipart", func(t *testing.T) {
+		// Write empty body, which is not allowed for content multipart.
+		writer := multipart.NewWriter(nil)
+
+		request := testutil.NewTestRequest(http.MethodPost, "/parse", nil)
+		request.Lang = server.Lang.GetDefault()
+		request.Header().Set("Content-Type", writer.FormDataContentType())
+
+		result := server.TestMiddleware(&Middleware{}, request, func(resp *goyave.Response, _ *goyave.Request) {
+			resp.Status(http.StatusBadRequest)
+		})
+
+		assert.NoError(t, result.Body.Close())
+		assert.Equal(t, http.StatusBadRequest, result.StatusCode)
+		assert.NotNil(t, request.Extra[goyave.ExtraParseError{}])
+		assert.NotPanics(t, func() {
+			extraError, ok := request.Extra[goyave.ExtraParseError{}].(error)
+			require.True(t, ok)
+			assert.ErrorIs(t, extraError, goyave.ErrInvalidContentForType)
+		})
+	})
+
+	t.Run("Error Reading Request Body", func(t *testing.T) {
+		// Create a test server that sends partial data
+		faultyRequest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Length", "10")
+			w.WriteHeader(http.StatusOK)
+			// Write only part of the promised data
+			_, err := w.Write([]byte("Partial "))
+			assert.NoError(t, err)
+
+			// Then flush the writer to send the incomplete response
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			// Don't close the connection, just stop writing
+		}))
+		defer faultyRequest.Close()
+
+		// Create a client that will make a request to our test server
+		client := faultyRequest.Client()
+		resp, err := client.Get(faultyRequest.URL)
+		require.NoError(t, err)
+
+		// Use the response body from our test server as the request body for our middleware
+		request := testutil.NewTestRequest(http.MethodPost, "/parse", resp.Body)
+		request.Lang = server.Lang.GetDefault()
+		request.Header().Set("Content-Type", "multipart/form-data")
+
+		result := server.TestMiddleware(&Middleware{}, request, func(resp *goyave.Response, _ *goyave.Request) {
+			resp.Status(http.StatusBadRequest)
+		})
+
+		assert.NoError(t, result.Body.Close())
+		assert.NoError(t, resp.Body.Close())
+
+		assert.Equal(t, http.StatusBadRequest, result.StatusCode)
+		assert.NotNil(t, request.Extra[goyave.ExtraParseError{}])
+		assert.NotPanics(t, func() {
+			extraError, ok := request.Extra[goyave.ExtraParseError{}].(error)
+			require.True(t, ok)
+			assert.ErrorIs(t, extraError, goyave.ErrErrorInRequestBody)
+			assert.Contains(t, extraError.Error(), "unexpected EOF")
+		})
 	})
 
 	t.Run("Form URL-encoded", func(t *testing.T) {

--- a/middleware/parse/parse_test.go
+++ b/middleware/parse/parse_test.go
@@ -2,6 +2,7 @@ package parse
 
 import (
 	"bytes"
+	"fmt"
 	"mime/multipart"
 	"net/http"
 	"strings"
@@ -107,6 +108,8 @@ func TestParseMiddleware(t *testing.T) {
 		})
 		assert.NoError(t, result.Body.Close())
 		assert.Equal(t, http.StatusBadRequest, result.StatusCode)
+		assert.NotNil(t, request.Extra[goyave.ExtraRequestError{}])
+		assert.Contains(t, request.Extra[goyave.ExtraRequestError{}].([]error), fmt.Errorf("request.json-empty-body"))
 	})
 
 	t.Run("Multipart", func(t *testing.T) {

--- a/middleware/parse/parse_test.go
+++ b/middleware/parse/parse_test.go
@@ -114,7 +114,7 @@ func TestParseMiddleware(t *testing.T) {
 		}{
 			{
 				name:     "JSON Invalid",
-				body:     []byte("{\"unclosed\""),
+				body:     []byte(`{"unclosed"`),
 				expected: http.StatusBadRequest,
 			},
 			{

--- a/request.go
+++ b/request.go
@@ -2,6 +2,7 @@ package goyave
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -32,6 +33,11 @@ type (
 	// ExtraRequestError the key used in `Context.Extra` to
 	// store specific request errors.
 	ExtraRequestError struct{}
+)
+
+var (
+	// ErrInvalidJSONBody error for invalid JSON body
+	ErrInvalidJSONBody = errors.New("request.json-invalid-body")
 )
 
 // Request represents a http request received by the server.

--- a/request.go
+++ b/request.go
@@ -36,8 +36,17 @@ type (
 )
 
 var (
-	// ErrInvalidJSONBody error for invalid JSON body
+	// ErrInvalidQuery error when an invalid query string is passed.
+	ErrInvalidQuery = errors.New("parse.invalid-query")
+
+	// ErrInvalidJSONBody error when an empty or malformed JSON body is sent.
 	ErrInvalidJSONBody = errors.New("parse.json-invalid-body")
+
+	// ErrInvalidContentForType error when e.g. a multipart form is not actually multipart, or empty.
+	ErrInvalidContentForType = errors.New("parse.invalid-content-for-type")
+
+	// ErrErrorInRequestBody error when e.g. a incoming request is not received properly.
+	ErrErrorInRequestBody = errors.New("parse.error-in-request-body")
 )
 
 // Request represents a http request received by the server.

--- a/request.go
+++ b/request.go
@@ -31,7 +31,7 @@ type (
 	ExtraQueryValidationError struct{}
 
 	// ExtraParseError the key used in `Context.Extra` to
-	// store specific request errors.
+	// store specific parsing errors.
 	ExtraParseError struct{}
 )
 

--- a/request.go
+++ b/request.go
@@ -28,9 +28,13 @@ type (
 	// ExtraQueryValidationError the key used in `Context.Extra` to
 	// store the query validation errors.
 	ExtraQueryValidationError struct{}
+
+	// ExtraRequestError the key used in `Context.Extra` to
+	// store specific request errors.
+	ExtraRequestError struct{}
 )
 
-// Request represents an http request received by the server.
+// Request represents a http request received by the server.
 type Request struct {
 	httpRequest *http.Request
 	Now         time.Time

--- a/request.go
+++ b/request.go
@@ -30,14 +30,14 @@ type (
 	// store the query validation errors.
 	ExtraQueryValidationError struct{}
 
-	// ExtraRequestError the key used in `Context.Extra` to
+	// ExtraParseError the key used in `Context.Extra` to
 	// store specific request errors.
-	ExtraRequestError struct{}
+	ExtraParseError struct{}
 )
 
 var (
 	// ErrInvalidJSONBody error for invalid JSON body
-	ErrInvalidJSONBody = errors.New("request.json-invalid-body")
+	ErrInvalidJSONBody = errors.New("parse.json-invalid-body")
 )
 
 // Request represents a http request received by the server.

--- a/response.go
+++ b/response.go
@@ -18,6 +18,7 @@ import (
 )
 
 const (
+	// StatusNginxNoResponse nginx status code: indicates server to return no information to the client and close the connection immediately.
 	StatusNginxNoResponse = 444
 )
 

--- a/response.go
+++ b/response.go
@@ -17,11 +17,6 @@ import (
 	"goyave.dev/goyave/v5/util/fsutil"
 )
 
-const (
-	// StatusNginxNoResponse nginx status code: indicates server to return no information to the client and close the connection immediately.
-	StatusNginxNoResponse = 444
-)
-
 var (
 	// ErrNotHijackable returned by response.Hijack() if the underlying
 	// http.ResponseWriter doesn't implement http.Hijacker. This can

--- a/response.go
+++ b/response.go
@@ -17,6 +17,10 @@ import (
 	"goyave.dev/goyave/v5/util/fsutil"
 )
 
+const (
+	StatusNginxNoResponse = 444
+)
+
 var (
 	// ErrNotHijackable returned by response.Hijack() if the underlying
 	// http.ResponseWriter doesn't implement http.Hijacker. This can

--- a/router.go
+++ b/router.go
@@ -122,12 +122,12 @@ func NewRouter(server *Server) *Router {
 	for i := http.StatusBadRequest; i <= http.StatusTeapot; i++ {
 		router.StatusHandler(&ErrorStatusHandler{}, i)
 	}
-	router.StatusHandler(&RequestErrorStatusHandler{}, http.StatusBadRequest)
+	router.StatusHandler(&ParseErrorStatusHandler{}, http.StatusBadRequest)
 	router.StatusHandler(&ValidationStatusHandler{}, http.StatusUnprocessableEntity)
 	for i := http.StatusLocked; i <= http.StatusUpgradeRequired; i++ {
 		router.StatusHandler(&ErrorStatusHandler{}, i)
 	}
-	router.StatusHandler(&ErrorStatusHandler{}, http.StatusMisdirectedRequest, http.StatusPreconditionRequired, http.StatusTooManyRequests, http.StatusRequestHeaderFieldsTooLarge, StatusNginxNoResponse, http.StatusUnavailableForLegalReasons)
+	router.StatusHandler(&ErrorStatusHandler{}, http.StatusMisdirectedRequest, http.StatusPreconditionRequired, http.StatusTooManyRequests, http.StatusRequestHeaderFieldsTooLarge, 444, http.StatusUnavailableForLegalReasons) // 444 is a nginx status code. Indicates server to return no information to the client and close the connection immediately
 	for i := http.StatusNotImplemented; i <= http.StatusLoopDetected; i++ {
 		router.StatusHandler(&ErrorStatusHandler{}, i)
 	}

--- a/router.go
+++ b/router.go
@@ -122,6 +122,7 @@ func NewRouter(server *Server) *Router {
 	for i := 400; i <= 418; i++ {
 		router.StatusHandler(&ErrorStatusHandler{}, i)
 	}
+	router.StatusHandler(&RequestErrorStatusHandler{}, http.StatusBadRequest)
 	router.StatusHandler(&ValidationStatusHandler{}, http.StatusUnprocessableEntity)
 	for i := 423; i <= 426; i++ {
 		router.StatusHandler(&ErrorStatusHandler{}, i)

--- a/router.go
+++ b/router.go
@@ -119,16 +119,19 @@ func NewRouter(server *Server) *Router {
 		Meta:       make(map[string]any),
 	}
 	router.StatusHandler(&PanicStatusHandler{}, http.StatusInternalServerError)
-	for i := 400; i <= 418; i++ {
+	for i := http.StatusBadRequest; i <= http.StatusTeapot; i++ {
 		router.StatusHandler(&ErrorStatusHandler{}, i)
 	}
 	router.StatusHandler(&RequestErrorStatusHandler{}, http.StatusBadRequest)
 	router.StatusHandler(&ValidationStatusHandler{}, http.StatusUnprocessableEntity)
-	for i := 423; i <= 426; i++ {
+	for i := http.StatusLocked; i <= http.StatusUpgradeRequired; i++ {
 		router.StatusHandler(&ErrorStatusHandler{}, i)
 	}
-	router.StatusHandler(&ErrorStatusHandler{}, 421, 428, 429, 431, 444, 451)
-	router.StatusHandler(&ErrorStatusHandler{}, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511)
+	router.StatusHandler(&ErrorStatusHandler{}, http.StatusMisdirectedRequest, http.StatusPreconditionRequired, http.StatusTooManyRequests, http.StatusRequestHeaderFieldsTooLarge, 444, http.StatusUnavailableForLegalReasons)
+	for i := http.StatusNotImplemented; i <= http.StatusLoopDetected; i++ {
+		router.StatusHandler(&ErrorStatusHandler{}, i)
+	}
+	router.StatusHandler(&ErrorStatusHandler{}, http.StatusNotExtended, http.StatusNetworkAuthenticationRequired)
 	router.GlobalMiddleware(&recoveryMiddleware{}, &languageMiddleware{})
 	return router
 }

--- a/router.go
+++ b/router.go
@@ -127,7 +127,7 @@ func NewRouter(server *Server) *Router {
 	for i := http.StatusLocked; i <= http.StatusUpgradeRequired; i++ {
 		router.StatusHandler(&ErrorStatusHandler{}, i)
 	}
-	router.StatusHandler(&ErrorStatusHandler{}, http.StatusMisdirectedRequest, http.StatusPreconditionRequired, http.StatusTooManyRequests, http.StatusRequestHeaderFieldsTooLarge, 444, http.StatusUnavailableForLegalReasons)
+	router.StatusHandler(&ErrorStatusHandler{}, http.StatusMisdirectedRequest, http.StatusPreconditionRequired, http.StatusTooManyRequests, http.StatusRequestHeaderFieldsTooLarge, StatusNginxNoResponse, http.StatusUnavailableForLegalReasons)
 	for i := http.StatusNotImplemented; i <= http.StatusLoopDetected; i++ {
 		router.StatusHandler(&ErrorStatusHandler{}, i)
 	}

--- a/status_handler.go
+++ b/status_handler.go
@@ -56,35 +56,25 @@ type RequestErrorStatusHandler struct {
 
 // Handle generic request (error) responses.
 func (h *RequestErrorStatusHandler) Handle(response *Response, request *Request) {
-	var errorMessages []string
-	var langName string
+	var errorMessage string
 
-	if request.Lang == nil {
-		langName = h.Lang().GetDefault().Name()
-	} else {
-		langName = request.Lang.Name()
-	}
-	lang := h.Lang().GetLanguage(langName)
+	lang := h.Lang().GetLanguage(request.Lang.Name())
 
-	if e, ok := request.Extra[ExtraRequestError{}]; ok {
+	if e, ok := request.Extra[ExtraParseError{}]; ok {
 		switch v := e.(type) {
-		case []error:
-			for _, err := range v {
-				errorMessages = append(errorMessages, lang.Get(err.Error()))
-			}
 		case error:
-			errorMessages = append(errorMessages, lang.Get(v.Error()))
+			errorMessage = lang.Get(v.Error())
 		case string:
-			errorMessages = append(errorMessages, lang.Get(v))
+			errorMessage = lang.Get(v)
 		default:
-			errorMessages = append(errorMessages, lang.Get(fmt.Sprintf("%v", v)))
+			errorMessage = lang.Get(fmt.Sprintf("%v", v))
 		}
 	}
 
-	messages := map[string][]string{
-		"error": errorMessages,
+	message := map[string]string{
+		"error": errorMessage,
 	}
-	response.JSON(response.GetStatus(), messages)
+	response.JSON(response.GetStatus(), message)
 }
 
 // ValidationStatusHandler for HTTP 422 errors.

--- a/status_handler.go
+++ b/status_handler.go
@@ -41,7 +41,7 @@ type ErrorStatusHandler struct {
 	Component
 }
 
-// Handle generic error reponses.
+// Handle generic error responses.
 func (*ErrorStatusHandler) Handle(response *Response, _ *Request) {
 	message := map[string]string{
 		"error": http.StatusText(response.GetStatus()),
@@ -49,10 +49,12 @@ func (*ErrorStatusHandler) Handle(response *Response, _ *Request) {
 	response.JSON(response.GetStatus(), message)
 }
 
+// RequestErrorStatusHandler a generic (error) status handler for requests.
 type RequestErrorStatusHandler struct {
 	Component
 }
 
+// Handle generic request (error) responses.
 func (h *RequestErrorStatusHandler) Handle(response *Response, request *Request) {
 	var errorMessages []string
 	var lang string

--- a/status_handler.go
+++ b/status_handler.go
@@ -57,24 +57,27 @@ type RequestErrorStatusHandler struct {
 // Handle generic request (error) responses.
 func (h *RequestErrorStatusHandler) Handle(response *Response, request *Request) {
 	var errorMessages []string
-	var lang string
+	var langName string
 
 	if request.Lang == nil {
-		lang = h.Lang().GetDefault().Name()
+		langName = h.Lang().GetDefault().Name()
 	} else {
-		lang = request.Lang.Name()
+		langName = request.Lang.Name()
 	}
+	lang := h.Lang().GetLanguage(langName)
 
 	if e, ok := request.Extra[ExtraRequestError{}]; ok {
 		switch v := e.(type) {
 		case []error:
 			for _, err := range v {
-				errorMessages = append(errorMessages, h.Lang().GetLanguage(lang).Get(err.Error()))
+				errorMessages = append(errorMessages, lang.Get(err.Error()))
 			}
+		case error:
+			errorMessages = append(errorMessages, lang.Get(v.Error()))
 		case string:
-			errorMessages = append(errorMessages, h.Lang().GetLanguage(lang).Get(v))
+			errorMessages = append(errorMessages, lang.Get(v))
 		default:
-			errorMessages = append(errorMessages, h.Lang().GetLanguage(lang).Get(fmt.Sprintf("%v", v)))
+			errorMessages = append(errorMessages, lang.Get(fmt.Sprintf("%v", v)))
 		}
 	}
 

--- a/status_handler_test.go
+++ b/status_handler_test.go
@@ -138,7 +138,7 @@ func TestRequestErrorStatusHandler(t *testing.T) {
 	handler := &RequestErrorStatusHandler{}
 	handler.Init(resp.server)
 
-	req.Extra[ExtraRequestError{}] = []error{fmt.Errorf("request.json-empty-body")}
+	req.Extra[ExtraRequestError{}] = []error{fmt.Errorf("request.json-invalid-body")}
 
 	handler.Handle(resp, req)
 
@@ -148,5 +148,5 @@ func TestRequestErrorStatusHandler(t *testing.T) {
 	assert.NoError(t, res.Body.Close())
 	require.NoError(t, err)
 
-	assert.Equal(t, "{\"error\":[\"The request Content-Type indicates JSON, but the request body is empty\"]}\n", string(body))
+	assert.Equal(t, "{\"error\":[\"The request Content-Type indicates JSON, but the request body is empty or invalid\"]}\n", string(body))
 }

--- a/status_handler_test.go
+++ b/status_handler_test.go
@@ -200,13 +200,12 @@ func TestParseErrorStatusHandler(t *testing.T) {
 	}
 }
 
-func TestParseErrorStatusHandlerWithNonSupportedErrorStruct(t *testing.T) {
+func TestParseErrorStatusHandlerWithoutExtra(t *testing.T) {
 	req, resp, recorder := prepareStatusHandlerTest()
 
 	handler := &ParseErrorStatusHandler{}
 	handler.Init(resp.server)
 
-	req.Extra[ExtraValidationError{}] = errors.New("some.other.error")
 	resp.Status(http.StatusBadRequest)
 
 	handler.Handle(resp, req)

--- a/status_handler_test.go
+++ b/status_handler_test.go
@@ -144,12 +144,12 @@ func TestRequestErrorStatusHandler(t *testing.T) {
 		{
 			name:             "WithString",
 			extra:            "parse.json-invalid-body",
-			expectedResponse: `{"error":"The request Content-Type indicates JSON, but the request body is empty or invalid"}` + "\n",
+			expectedResponse: `{"error":"The request Content-Type indicates JSON, but the request body is empty or invalid."}` + "\n",
 		},
 		{
 			name:             "WithError",
 			extra:            ErrInvalidJSONBody,
-			expectedResponse: `{"error":"The request Content-Type indicates JSON, but the request body is empty or invalid"}` + "\n",
+			expectedResponse: `{"error":"The request Content-Type indicates JSON, but the request body is empty or invalid."}` + "\n",
 		},
 		{
 			name:             "WithIntegerValue",

--- a/status_handler_test.go
+++ b/status_handler_test.go
@@ -20,8 +20,11 @@ func prepareStatusHandlerTest() (*Request, *Response, *httptest.ResponseRecorder
 	if err != nil {
 		panic(err)
 	}
+
 	httpReq := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req := NewRequest(httpReq)
+	req.Lang = server.Lang.GetDefault()
+
 	recorder := httptest.NewRecorder()
 	resp := NewResponse(server, req, recorder)
 	return req, resp, recorder
@@ -139,29 +142,19 @@ func TestRequestErrorStatusHandler(t *testing.T) {
 		expectedResponse string
 	}{
 		{
-			name:             "WithSliceOfErrors",
-			extra:            []error{ErrInvalidJSONBody},
-			expectedResponse: `{"error":["The request Content-Type indicates JSON, but the request body is empty or invalid"]}` + "\n",
-		},
-		{
 			name:             "WithString",
-			extra:            "request.json-invalid-body",
-			expectedResponse: `{"error":["The request Content-Type indicates JSON, but the request body is empty or invalid"]}` + "\n",
+			extra:            "parse.json-invalid-body",
+			expectedResponse: `{"error":"The request Content-Type indicates JSON, but the request body is empty or invalid"}` + "\n",
 		},
 		{
-			name:             "WithSingleError",
+			name:             "WithError",
 			extra:            ErrInvalidJSONBody,
-			expectedResponse: `{"error":["The request Content-Type indicates JSON, but the request body is empty or invalid"]}` + "\n",
+			expectedResponse: `{"error":"The request Content-Type indicates JSON, but the request body is empty or invalid"}` + "\n",
 		},
 		{
 			name:             "WithIntegerValue",
 			extra:            123,
-			expectedResponse: `{"error":["123"]}` + "\n",
-		},
-		{
-			name:             "WithAny",
-			extra:            []any{ErrInvalidJSONBody},
-			expectedResponse: `{"error":["[request.json-invalid-body]"]}` + "\n",
+			expectedResponse: `{"error":"123"}` + "\n",
 		},
 	}
 
@@ -172,7 +165,7 @@ func TestRequestErrorStatusHandler(t *testing.T) {
 			handler := &RequestErrorStatusHandler{}
 			handler.Init(resp.server)
 
-			req.Extra[ExtraRequestError{}] = tt.extra
+			req.Extra[ExtraParseError{}] = tt.extra
 
 			handler.Handle(resp, req)
 


### PR DESCRIPTION
## References
**Issue(s):** closes #216  

## Description
As per discusion in Discord, I've added a message when the parser returns a `400` bad request when Content-Type JSON is given, but no, or an invalid body. I've handled this via `response.Extra[goyave.ExtraRequestError{}]`. 

It also translates.

### Possible drawbacks
Let me know :)
