### PR TITLE
#215 - Response: add support for flushing

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/samber/lo"
 	"goyave.dev/goyave/v5"
+	"goyave.dev/goyave/v5/util/errors"
 )
 
 // Context contains all information needed for a `Formatter`.
@@ -58,7 +59,8 @@ func NewWriter(server *goyave.Server, response *goyave.Response, request *goyave
 // for later logging.
 func (w *Writer) Write(b []byte) (int, error) {
 	w.length += len(b)
-	return w.CommonWriter.Write(b)
+	n, err := w.CommonWriter.Write(b)
+	return n, errors.New(err)
 }
 
 // Close the writer and its child ResponseWriter, flushing response
@@ -79,7 +81,7 @@ func (w *Writer) Close() error {
 		w.Logger().Info(message, lo.Map(attrs, func(a slog.Attr, _ int) any { return a })...)
 	}
 
-	return w.CommonWriter.Close()
+	return errors.New(w.CommonWriter.Close())
 }
 
 // AccessMiddleware captures response data and outputs it to the logger at the

--- a/middleware/compress/compress.go
+++ b/middleware/compress/compress.go
@@ -27,29 +27,37 @@ type Encoder interface {
 }
 
 type compressWriter struct {
-	io.WriteCloser
-	http.ResponseWriter
-	childWriter io.Writer
+	goyave.CommonWriter
+	responseWriter http.ResponseWriter
+	childWriter    io.Writer
 }
 
 func (w *compressWriter) PreWrite(b []byte) {
 	if pr, ok := w.childWriter.(goyave.PreWriter); ok {
 		pr.PreWrite(b)
 	}
-	h := w.ResponseWriter.Header()
+	h := w.responseWriter.Header()
 	if h.Get("Content-Type") == "" {
 		h.Set("Content-Type", http.DetectContentType(b))
 	}
 	h.Del("Content-Length")
 }
 
-func (w *compressWriter) Write(b []byte) (int, error) {
-	n, err := w.WriteCloser.Write(b)
-	return n, errors.New(err)
+func (w *compressWriter) Flush() error {
+	if err := w.CommonWriter.Flush(); err != nil {
+		return errors.New(err)
+	}
+	switch flusher := w.childWriter.(type) {
+	case goyave.Flusher:
+		return errors.New(flusher.Flush())
+	case http.Flusher:
+		flusher.Flush()
+	}
+	return nil
 }
 
 func (w *compressWriter) Close() error {
-	err := errors.New(w.WriteCloser.Close())
+	err := errors.New(w.CommonWriter.Close())
 
 	if wr, ok := w.childWriter.(io.Closer); ok {
 		return errors.New(wr.Close())
@@ -106,8 +114,8 @@ func (m *Middleware) Handle(next goyave.Handler) goyave.Handler {
 
 		respWriter := response.Writer()
 		compressWriter := &compressWriter{
-			WriteCloser:    encoder.NewWriter(respWriter),
-			ResponseWriter: response,
+			CommonWriter:   goyave.NewCommonWriter(encoder.NewWriter(respWriter)),
+			responseWriter: response,
 			childWriter:    respWriter,
 		}
 		response.SetWriter(compressWriter)

--- a/middleware/compress/compress_test.go
+++ b/middleware/compress/compress_test.go
@@ -158,8 +158,8 @@ func TestCompressWriter(t *testing.T) {
 	response := httptest.NewRecorder()
 
 	writer := &compressWriter{
-		WriteCloser:    encoder.NewWriter(closeableWriter),
-		ResponseWriter: response,
+		CommonWriter:   goyave.NewCommonWriter(encoder.NewWriter(closeableWriter)),
+		responseWriter: response,
 		childWriter:    closeableWriter,
 	}
 
@@ -169,6 +169,8 @@ func TestCompressWriter(t *testing.T) {
 
 	require.NoError(t, writer.Close())
 	assert.True(t, closeableWriter.closed)
+
+	// TODO flush test
 }
 
 type testEncoder struct {

--- a/middleware/compress/compress_test.go
+++ b/middleware/compress/compress_test.go
@@ -3,6 +3,7 @@ package compress
 import (
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,10 +17,20 @@ import (
 	"goyave.dev/goyave/v5/util/testutil"
 )
 
+type testBuf struct {
+	*bytes.Buffer
+	flushErr error
+}
+
+func (w *testBuf) Flush() error {
+	return w.flushErr
+}
+
 type closeableChildWriter struct {
 	io.Writer
 	closed     bool
 	preWritten bool
+	flushed    bool
 }
 
 func (w *closeableChildWriter) PreWrite(b []byte) {
@@ -29,12 +40,37 @@ func (w *closeableChildWriter) PreWrite(b []byte) {
 	}
 }
 
+func (w *closeableChildWriter) Flush() error {
+	w.flushed = true
+	switch flusher := w.Writer.(type) {
+	case goyave.Flusher:
+		return flusher.Flush()
+	case http.Flusher:
+		flusher.Flush()
+	}
+	return nil
+}
+
 func (w *closeableChildWriter) Close() error {
 	w.closed = true
 	if wr, ok := w.Writer.(io.Closer); ok {
 		return wr.Close()
 	}
 	return nil
+}
+
+type closeableChildWriterHTTPFlusher struct {
+	*closeableChildWriter
+}
+
+func (w *closeableChildWriterHTTPFlusher) Flush() {
+	w.flushed = true
+	switch flusher := w.Writer.(type) {
+	case goyave.Flusher:
+		_ = flusher.Flush()
+	case http.Flusher:
+		flusher.Flush()
+	}
 }
 
 func TestCompressMiddleware(t *testing.T) {
@@ -149,14 +185,13 @@ func TestCompressWriter(t *testing.T) {
 		Level: gzip.BestCompression,
 	}
 
-	buf := bytes.NewBuffer([]byte{})
+	buf := &testBuf{Buffer: bytes.NewBuffer([]byte{})}
 	closeableWriter := &closeableChildWriter{
 		Writer: buf,
 		closed: false,
 	}
 
 	response := httptest.NewRecorder()
-
 	writer := &compressWriter{
 		CommonWriter:   goyave.NewCommonWriter(encoder.NewWriter(closeableWriter)),
 		responseWriter: response,
@@ -164,13 +199,33 @@ func TestCompressWriter(t *testing.T) {
 	}
 
 	writer.PreWrite([]byte("hello world"))
-
 	assert.True(t, closeableWriter.preWritten)
+
+	assert.NoError(t, writer.Flush())
+	assert.True(t, closeableWriter.flushed)
+
+	buf.flushErr = fmt.Errorf("test error")
+	assert.ErrorIs(t, writer.Flush(), buf.flushErr)
 
 	require.NoError(t, writer.Close())
 	assert.True(t, closeableWriter.closed)
 
-	// TODO flush test
+	t.Run("http_flusher", func(t *testing.T) {
+		buf := &testBuf{Buffer: bytes.NewBuffer([]byte{})}
+		closeableWriter := &closeableChildWriterHTTPFlusher{
+			closeableChildWriter: &closeableChildWriter{
+				Writer: buf,
+			},
+		}
+		response := httptest.NewRecorder()
+		writer := &compressWriter{
+			CommonWriter:   goyave.NewCommonWriter(encoder.NewWriter(closeableWriter)),
+			responseWriter: response,
+			childWriter:    closeableWriter,
+		}
+		assert.NoError(t, writer.Flush())
+		assert.True(t, closeableWriter.flushed)
+	})
 }
 
 type testEncoder struct {

--- a/response.go
+++ b/response.go
@@ -44,7 +44,7 @@ type Flusher interface {
 // CommonWriter is a component meant to be used with composition
 // to avoid having to implement the base behavior of the common interfaces
 // a chained writer has to implement (`PreWrite()`, `Write()`, `Close()`, `Flush()`)
-type CommonWriter struct { // TODO test CommonWriter
+type CommonWriter struct {
 	Component
 	wr io.Writer
 }

--- a/response_test.go
+++ b/response_test.go
@@ -235,6 +235,8 @@ func TestResponse(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.status) // Ensures PreWrite has been called
 		assert.Equal(t, http.StatusOK, res.StatusCode)
 		assert.Equal(t, "hello world", string(body))
+
+		// TODO test PreWrite only called once
 	})
 
 	t.Run("Hijack", func(t *testing.T) {
@@ -510,4 +512,6 @@ func TestResponse(t *testing.T) {
 			assert.False(t, resp.WriteDBError(nil))
 		})
 	})
+
+	// TODO flush test
 }


### PR DESCRIPTION
## References

**Issue(s):** closes #215

## Description

- Make `Response` implement `http.Flusher`
- Call `PreWrite` only once on the first `Write`
- Add `CommonWriter` to reduce chained writers boilerplate
- Use `CommonWriter` for log and compress middleware