### PR TITLE
Support middleware compression with Zlib, LZW, Brotli, and Zstd encoders

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ github.com/Code-Hex/uniseg v0.2.0 h1:QB/2UJFvEuRLSZqe+Sb1XQBTWjqGVbZoC6oSWzQRKws
 github.com/Code-Hex/uniseg v0.2.0/go.mod h1:/ndS2tP+X1lk2HUOcXWGtVTxVq0lWilwgMa4CbzdRsg=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/middleware/compress/brotli.go
+++ b/middleware/compress/brotli.go
@@ -1,0 +1,40 @@
+package compress
+
+import (
+	"io"
+
+	"github.com/andybalholm/brotli"
+	"goyave.dev/goyave/v5/util/errors"
+)
+
+// Brotli encoder for the brotli compression format
+type Brotli struct {
+	// Quality controls the compression-speed vs compression-density trade-offs.
+	// The higher the quality, the slower the compression. Range is 0 to 11.
+	Quality int
+	// LGWin is the base 2 logarithm of the sliding window size.
+	// Range is 10 to 24. 0 indicates automatic configuration based on Quality.
+	LGWin int
+}
+
+// Encoding returns "brotli".
+func (w *Brotli) Encoding() string {
+	return "brotli"
+}
+
+// NewWriter returns a new `brotli.Writer` using the
+// Compression Quality and LGWin provided in the Brotli encoder
+func (w *Brotli) NewWriter(wr io.Writer) io.WriteCloser {
+	if w.Quality < 0 || w.Quality > 11 {
+		panic(errors.New("Brotli Compression Level must be in range [0, 11]"))
+	}
+	if w.LGWin != 0 {
+		if w.LGWin < 10 || w.LGWin > 24 {
+			panic(errors.New("Brotli LGWin must be either 0 or within range [10, 24]"))
+		}
+	}
+	return brotli.NewWriterOptions(wr, brotli.WriterOptions{
+		Quality: w.Quality,
+		LGWin:   w.LGWin,
+	})
+}

--- a/middleware/compress/brotli.go
+++ b/middleware/compress/brotli.go
@@ -7,7 +7,7 @@ import (
 	"goyave.dev/goyave/v5/util/errors"
 )
 
-// Brotli encoder for the brotli compression format
+// Brotli encoder for the br compression format
 type Brotli struct {
 	// Quality controls the compression-speed vs compression-density trade-offs.
 	// The higher the quality, the slower the compression. Range is 0 to 11.
@@ -17,15 +17,15 @@ type Brotli struct {
 	LGWin int
 }
 
-// Encoding returns "brotli".
+// Encoding returns "br".
 func (w *Brotli) Encoding() string {
-	return "brotli"
+	return "br"
 }
 
 // NewWriter returns a new `brotli.Writer` using the
 // Compression Quality and LGWin provided in the Brotli encoder
 func (w *Brotli) NewWriter(wr io.Writer) io.WriteCloser {
-	if w.Quality < 0 || w.Quality > 11 {
+	if w.Quality < brotli.BestSpeed || w.Quality > brotli.BestCompression {
 		panic(errors.New("Brotli Compression Level must be in range [0, 11]"))
 	}
 	if w.LGWin != 0 {

--- a/middleware/compress/brotli_test.go
+++ b/middleware/compress/brotli_test.go
@@ -1,0 +1,68 @@
+package compress
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"goyave.dev/goyave/v5"
+	"goyave.dev/goyave/v5/config"
+	"goyave.dev/goyave/v5/util/testutil"
+)
+
+func TestBrotliEncoder(t *testing.T) {
+	encoder := &Brotli{
+		Quality: 6,
+	}
+
+	assert.Equal(t, "brotli", encoder.Encoding())
+
+	buf := bytes.NewBuffer([]byte{})
+	writer := encoder.NewWriter(buf)
+	if assert.NotNil(t, writer) {
+		_, ok := writer.(*brotli.Writer)
+		assert.True(t, ok)
+	}
+
+	assert.Panics(t, func() {
+		// Invalid Level
+		encoder := &Brotli{
+			Quality: 12,
+		}
+		encoder.NewWriter(bytes.NewBuffer([]byte{}))
+	})
+}
+
+func TestBrotliCompression(t *testing.T) {
+	server := testutil.NewTestServerWithOptions(t, goyave.Options{Config: config.LoadDefault()})
+
+	handler := func(resp *goyave.Response, _ *goyave.Request) {
+		resp.Header().Set("Content-Length", "1234")
+		resp.String(http.StatusOK, "hello world")
+	}
+
+	compressMiddleWare := &Middleware{
+		Encoders: []Encoder{
+			&Brotli{
+				Quality: 6,
+				LGWin:   15,
+			},
+		},
+	}
+
+	request := testutil.NewTestRequest(http.MethodGet, "/brotli", nil)
+	request.Header().Set("Accept-Encoding", "brotli")
+	result := server.TestMiddleware(compressMiddleWare, request, handler)
+
+	reader := brotli.NewReader(result.Body)
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.NoError(t, result.Body.Close())
+	assert.Equal(t, "hello world", string(body))
+	assert.Equal(t, "brotli", result.Header.Get("Content-Encoding"))
+	assert.Empty(t, result.Header.Get("Content-Length"))
+}

--- a/middleware/compress/brotli_test.go
+++ b/middleware/compress/brotli_test.go
@@ -39,7 +39,7 @@ func TestBrotliEncoder(t *testing.T) {
 	assert.Panics(t, func() {
 		// Invalid LGWin
 		encoder := &Brotli{
-			Quality: 12,
+			Quality: 11,
 			LGWin:   9,
 		}
 		encoder.NewWriter(bytes.NewBuffer([]byte{}))

--- a/middleware/compress/brotli_test.go
+++ b/middleware/compress/brotli_test.go
@@ -19,7 +19,7 @@ func TestBrotliEncoder(t *testing.T) {
 		Quality: 6,
 	}
 
-	assert.Equal(t, "brotli", encoder.Encoding())
+	assert.Equal(t, "br", encoder.Encoding())
 
 	buf := bytes.NewBuffer([]byte{})
 	writer := encoder.NewWriter(buf)
@@ -29,9 +29,18 @@ func TestBrotliEncoder(t *testing.T) {
 	}
 
 	assert.Panics(t, func() {
-		// Invalid Level
+		// Invalid Quality
 		encoder := &Brotli{
 			Quality: 12,
+		}
+		encoder.NewWriter(bytes.NewBuffer([]byte{}))
+	})
+
+	assert.Panics(t, func() {
+		// Invalid LGWin
+		encoder := &Brotli{
+			Quality: 12,
+			LGWin:   9,
 		}
 		encoder.NewWriter(bytes.NewBuffer([]byte{}))
 	})
@@ -55,7 +64,7 @@ func TestBrotliCompression(t *testing.T) {
 	}
 
 	request := testutil.NewTestRequest(http.MethodGet, "/brotli", nil)
-	request.Header().Set("Accept-Encoding", "brotli")
+	request.Header().Set("Accept-Encoding", "br")
 	result := server.TestMiddleware(compressMiddleWare, request, handler)
 
 	reader := brotli.NewReader(result.Body)
@@ -63,6 +72,6 @@ func TestBrotliCompression(t *testing.T) {
 	require.NoError(t, err)
 	assert.NoError(t, result.Body.Close())
 	assert.Equal(t, "hello world", string(body))
-	assert.Equal(t, "brotli", result.Header.Get("Content-Encoding"))
+	assert.Equal(t, "br", result.Header.Get("Content-Encoding"))
 	assert.Empty(t, result.Header.Get("Content-Length"))
 }

--- a/middleware/compress/lzw.go
+++ b/middleware/compress/lzw.go
@@ -1,0 +1,33 @@
+package compress
+
+import (
+	"compress/lzw"
+	"io"
+
+	"goyave.dev/goyave/v5/util/errors"
+)
+
+// Lzw encoder for the gzip format using Go's standard `compress/lzw` package.
+//
+// Takes an Order specifying the bit ordering in an LZW data stream level,
+// and number of bits to use for literal codes, litWidth, as parameters.
+// Accepted values are defined by constants
+// in the standard `compress/lzw` package.
+type Lzw struct {
+	Order    lzw.Order
+	LitWidth int
+}
+
+// Encoding returns "lzw".
+func (w *Lzw) Encoding() string {
+	return "lzw"
+}
+
+// NewWriter returns a new `compress/lzw.Writer` using an LZW bit ordering type,
+// and an int for number of bits to use for literal codes - must be within range [2, 8]
+func (w *Lzw) NewWriter(wr io.Writer) io.WriteCloser {
+	if w.LitWidth < 2 || w.LitWidth > 8 {
+		panic(errors.New("LitWidth must be in range [2, 8]"))
+	}
+	return lzw.NewWriter(wr, w.Order, w.LitWidth)
+}

--- a/middleware/compress/lzw.go
+++ b/middleware/compress/lzw.go
@@ -7,25 +7,34 @@ import (
 	"goyave.dev/goyave/v5/util/errors"
 )
 
-// Lzw encoder for the gzip format using Go's standard `compress/lzw` package.
+// LZW encoder for the compress format using Go's standard `compress/lzw` package.
 //
 // Takes an Order specifying the bit ordering in an LZW data stream level,
 // and number of bits to use for literal codes, litWidth, as parameters.
 // Accepted values are defined by constants
 // in the standard `compress/lzw` package.
-type Lzw struct {
-	Order    lzw.Order
+type LZW struct {
+	// Order specifies the bit ordering in an LZW data stream.
+	// It is optional, and the default value is lzw.LSB (Least Significant Bits)
+	Order lzw.Order
+	// LitWidth specifies the number of bits to use for literal codes
+	// Must be in the range [2,8] and is typically 8.
+	// Input bytes must be less than 1<<litWidth.
 	LitWidth int
 }
 
-// Encoding returns "lzw".
-func (w *Lzw) Encoding() string {
-	return "lzw"
+// Encoding returns "compress".
+func (w *LZW) Encoding() string {
+	return "compress"
 }
 
 // NewWriter returns a new `compress/lzw.Writer` using an LZW bit ordering type,
 // and an int for number of bits to use for literal codes - must be within range [2, 8]
-func (w *Lzw) NewWriter(wr io.Writer) io.WriteCloser {
+// Default to a LitWidth of 8 if LitWidth was not set
+func (w *LZW) NewWriter(wr io.Writer) io.WriteCloser {
+	if w.LitWidth == 0 {
+		w.LitWidth = 8
+	}
 	if w.LitWidth < 2 || w.LitWidth > 8 {
 		panic(errors.New("LitWidth must be in range [2, 8]"))
 	}

--- a/middleware/compress/lzw_test.go
+++ b/middleware/compress/lzw_test.go
@@ -1,0 +1,70 @@
+package compress
+
+import (
+	"bytes"
+	"compress/lzw"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"goyave.dev/goyave/v5"
+	"goyave.dev/goyave/v5/config"
+	"goyave.dev/goyave/v5/util/testutil"
+)
+
+func TestLzwEncoder(t *testing.T) {
+	encoder := &Lzw{
+		Order:    lzw.LSB,
+		LitWidth: 5,
+	}
+
+	assert.Equal(t, "lzw", encoder.Encoding())
+
+	buf := bytes.NewBuffer([]byte{})
+	writer := encoder.NewWriter(buf)
+	if assert.NotNil(t, writer) {
+		_, ok := writer.(*lzw.Writer)
+		assert.True(t, ok)
+	}
+
+	assert.Panics(t, func() {
+		// Invalid LitWidth
+		encoder := &Lzw{
+			Order:    lzw.LSB,
+			LitWidth: 9,
+		}
+		encoder.NewWriter(bytes.NewBuffer([]byte{}))
+	})
+}
+
+func TestLzwCompression(t *testing.T) {
+	server := testutil.NewTestServerWithOptions(t, goyave.Options{Config: config.LoadDefault()})
+
+	handler := func(resp *goyave.Response, _ *goyave.Request) {
+		resp.Header().Set("Content-Length", "1234")
+		resp.String(http.StatusOK, "hello world")
+	}
+
+	compressMiddleWare := &Middleware{
+		Encoders: []Encoder{
+			&Lzw{
+				Order:    lzw.LSB,
+				LitWidth: 8,
+			},
+		},
+	}
+
+	request := testutil.NewTestRequest(http.MethodGet, "/lzw", nil)
+	request.Header().Set("Accept-Encoding", "lzw")
+	result := server.TestMiddleware(compressMiddleWare, request, handler)
+
+	reader := lzw.NewReader(result.Body, lzw.LSB, 8)
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.NoError(t, result.Body.Close())
+	assert.Equal(t, "hello world", string(body))
+	assert.Equal(t, "lzw", result.Header.Get("Content-Encoding"))
+	assert.Empty(t, result.Header.Get("Content-Length"))
+}

--- a/middleware/compress/lzw_test.go
+++ b/middleware/compress/lzw_test.go
@@ -25,6 +25,7 @@ func TestLzwEncoder(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	writer := encoder.NewWriter(buf)
 	require.NotNil(t, writer)
+	assert.Equal(t, 8, encoder.LitWidth)
 	_, ok := writer.(*lzw.Writer)
 	assert.True(t, ok)
 

--- a/middleware/compress/zlib.go
+++ b/middleware/compress/zlib.go
@@ -7,17 +7,18 @@ import (
 	"goyave.dev/goyave/v5/util/errors"
 )
 
-// Zlib encoder for the gzip format using Go's standard `compress/gzip` package.
+// Zlib encoder for the deflate format using Go's standard `compress/zlib` package.
 // Takes a compression level and "dict" ([]byte) as parameters. Accepted values are defined by constants
 // in the standard `compress/zlib` package.
 type Zlib struct {
+	// The dictionary is optional and may be nil
 	Dict  []byte
 	Level int
 }
 
-// Encoding returns "zlib".
+// Encoding returns "deflate".
 func (w *Zlib) Encoding() string {
-	return "zlib"
+	return "deflate"
 }
 
 // NewWriter returns a new `compress/zlib.Writer` using the compression level

--- a/middleware/compress/zlib.go
+++ b/middleware/compress/zlib.go
@@ -1,0 +1,33 @@
+package compress
+
+import (
+	"compress/zlib"
+	"io"
+
+	"goyave.dev/goyave/v5/util/errors"
+)
+
+// Zlib encoder for the gzip format using Go's standard `compress/gzip` package.
+//
+// Takes a compression level and "dict" ([]byte) as parameters. Accepted values are defined by constants
+// in the standard `compress/zlib` package.
+type Zlib struct {
+	Level int
+	Dict  []byte
+}
+
+// Encoding returns "zlib".
+func (w *Zlib) Encoding() string {
+	return "zlib"
+}
+
+// NewWriter returns a new `compress/zlib.Writer` using the compression level
+// defined in this Zlib encoder.
+// You may also provide a dict to compress with, or leave as nil
+func (w *Zlib) NewWriter(wr io.Writer) io.WriteCloser {
+	writer, err := zlib.NewWriterLevelDict(wr, w.Level, w.Dict)
+	if err != nil {
+		panic(errors.New(err))
+	}
+	return writer
+}

--- a/middleware/compress/zlib.go
+++ b/middleware/compress/zlib.go
@@ -8,12 +8,11 @@ import (
 )
 
 // Zlib encoder for the gzip format using Go's standard `compress/gzip` package.
-//
 // Takes a compression level and "dict" ([]byte) as parameters. Accepted values are defined by constants
 // in the standard `compress/zlib` package.
 type Zlib struct {
-	Level int
 	Dict  []byte
+	Level int
 }
 
 // Encoding returns "zlib".

--- a/middleware/compress/zlib_test.go
+++ b/middleware/compress/zlib_test.go
@@ -1,0 +1,97 @@
+package compress
+
+import (
+	"bytes"
+	"compress/zlib"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"goyave.dev/goyave/v5"
+	"goyave.dev/goyave/v5/config"
+	"goyave.dev/goyave/v5/util/testutil"
+)
+
+func TestZlibEncoder(t *testing.T) {
+	encoder := &Zlib{
+		Level: zlib.BestCompression,
+		Dict:  nil,
+	}
+
+	assert.Equal(t, "zlib", encoder.Encoding())
+	assert.Equal(t, zlib.BestCompression, encoder.Level)
+
+	buf := bytes.NewBuffer([]byte{})
+	writer := encoder.NewWriter(buf)
+	if assert.NotNil(t, writer) {
+		_, ok := writer.(*zlib.Writer)
+		assert.True(t, ok)
+	}
+
+	assert.Panics(t, func() {
+		// Invalid level
+		encoder := &Zlib{
+			Level: -3,
+			Dict:  nil,
+		}
+		encoder.NewWriter(bytes.NewBuffer([]byte{}))
+	})
+}
+
+func TestZlibCompression(t *testing.T) {
+	server := testutil.NewTestServerWithOptions(t, goyave.Options{Config: config.LoadDefault()})
+
+	handler := func(resp *goyave.Response, _ *goyave.Request) {
+		resp.Header().Set("Content-Length", "1234")
+		resp.String(http.StatusOK, "hello world")
+	}
+
+	compressMiddleWare := &Middleware{
+		Encoders: []Encoder{
+			&Zlib{Level: zlib.BestCompression, Dict: nil},
+		},
+	}
+
+	request := testutil.NewTestRequest(http.MethodGet, "/zlib", nil)
+	request.Header().Set("Accept-Encoding", "zlib")
+	result := server.TestMiddleware(compressMiddleWare, request, handler)
+
+	reader, err := zlib.NewReader(result.Body)
+	require.NoError(t, err)
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.NoError(t, result.Body.Close())
+	assert.Equal(t, "hello world", string(body))
+	assert.Equal(t, "zlib", result.Header.Get("Content-Encoding"))
+	assert.Empty(t, result.Header.Get("Content-Length"))
+}
+
+func TestZlibCompressionNoDict(t *testing.T) {
+	server := testutil.NewTestServerWithOptions(t, goyave.Options{Config: config.LoadDefault()})
+
+	handler := func(resp *goyave.Response, _ *goyave.Request) {
+		resp.Header().Set("Content-Length", "1234")
+		resp.String(http.StatusOK, "hello world")
+	}
+
+	compressMiddleWare := &Middleware{
+		Encoders: []Encoder{
+			&Zlib{Level: zlib.BestCompression},
+		},
+	}
+
+	request := testutil.NewTestRequest(http.MethodGet, "/zlib", nil)
+	request.Header().Set("Accept-Encoding", "zlib")
+	result := server.TestMiddleware(compressMiddleWare, request, handler)
+
+	reader, err := zlib.NewReader(result.Body)
+	require.NoError(t, err)
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.NoError(t, result.Body.Close())
+	assert.Equal(t, "hello world", string(body))
+	assert.Equal(t, "zlib", result.Header.Get("Content-Encoding"))
+	assert.Empty(t, result.Header.Get("Content-Length"))
+}

--- a/middleware/compress/zlib_test.go
+++ b/middleware/compress/zlib_test.go
@@ -20,7 +20,7 @@ func TestZlibEncoder(t *testing.T) {
 		Dict:  nil,
 	}
 
-	assert.Equal(t, "zlib", encoder.Encoding())
+	assert.Equal(t, "deflate", encoder.Encoding())
 	assert.Equal(t, zlib.BestCompression, encoder.Level)
 
 	buf := bytes.NewBuffer([]byte{})
@@ -55,7 +55,7 @@ func TestZlibCompression(t *testing.T) {
 	}
 
 	request := testutil.NewTestRequest(http.MethodGet, "/zlib", nil)
-	request.Header().Set("Accept-Encoding", "zlib")
+	request.Header().Set("Accept-Encoding", "deflate")
 	result := server.TestMiddleware(compressMiddleWare, request, handler)
 
 	reader, err := zlib.NewReader(result.Body)
@@ -64,7 +64,7 @@ func TestZlibCompression(t *testing.T) {
 	require.NoError(t, err)
 	assert.NoError(t, result.Body.Close())
 	assert.Equal(t, "hello world", string(body))
-	assert.Equal(t, "zlib", result.Header.Get("Content-Encoding"))
+	assert.Equal(t, "deflate", result.Header.Get("Content-Encoding"))
 	assert.Empty(t, result.Header.Get("Content-Length"))
 }
 
@@ -83,7 +83,7 @@ func TestZlibCompressionNoDict(t *testing.T) {
 	}
 
 	request := testutil.NewTestRequest(http.MethodGet, "/zlib", nil)
-	request.Header().Set("Accept-Encoding", "zlib")
+	request.Header().Set("Accept-Encoding", "deflate")
 	result := server.TestMiddleware(compressMiddleWare, request, handler)
 
 	reader, err := zlib.NewReader(result.Body)
@@ -92,6 +92,6 @@ func TestZlibCompressionNoDict(t *testing.T) {
 	require.NoError(t, err)
 	assert.NoError(t, result.Body.Close())
 	assert.Equal(t, "hello world", string(body))
-	assert.Equal(t, "zlib", result.Header.Get("Content-Encoding"))
+	assert.Equal(t, "deflate", result.Header.Get("Content-Encoding"))
 	assert.Empty(t, result.Header.Get("Content-Length"))
 }

--- a/middleware/compress/zstd.go
+++ b/middleware/compress/zstd.go
@@ -1,0 +1,30 @@
+package compress
+
+import (
+	"io"
+
+	"github.com/klauspost/compress/zstd"
+	"goyave.dev/goyave/v5/util/errors"
+)
+
+// Zstd encoder for the Zstandard compression algorithm
+// You may provide a list of zstd.EOptions as parameters.
+// Refer to the package documentation for more information
+type Zstd struct {
+	Options []zstd.EOption
+}
+
+// Encoding returns "zstd".
+func (w *Zstd) Encoding() string {
+	return "zstd"
+}
+
+// NewWriter returns a new `zstd.Encoder` using the zstd.EOptions
+// defined in the Zstd encoder.
+func (w *Zstd) NewWriter(wr io.Writer) io.WriteCloser {
+	writer, err := zstd.NewWriter(wr, w.Options...)
+	if err != nil {
+		panic(errors.New(err))
+	}
+	return writer
+}

--- a/middleware/compress/zstd_test.go
+++ b/middleware/compress/zstd_test.go
@@ -23,10 +23,9 @@ func TestZstdEncoder(t *testing.T) {
 
 	buf := bytes.NewBuffer([]byte{})
 	writer := encoder.NewWriter(buf)
-	if assert.NotNil(t, writer) {
-		_, ok := writer.(*zstd.Encoder)
-		assert.True(t, ok)
-	}
+	require.NotNil(t, writer)
+	_, ok := writer.(*zstd.Encoder)
+	assert.True(t, ok)
 
 	assert.Panics(t, func() {
 		// Invalid EncoderConcurrency
@@ -62,7 +61,9 @@ func TestZstdCompression(t *testing.T) {
 	request.Header().Set("Accept-Encoding", "zstd")
 	result := server.TestMiddleware(compressMiddleWare, request, handler)
 
-	reader, _ := zstd.NewReader(result.Body)
+	reader, err := zstd.NewReader(result.Body)
+	require.NoError(t, err)
+
 	body, err := io.ReadAll(reader)
 	require.NoError(t, err)
 	assert.NoError(t, result.Body.Close())

--- a/middleware/compress/zstd_test.go
+++ b/middleware/compress/zstd_test.go
@@ -1,0 +1,72 @@
+package compress
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"goyave.dev/goyave/v5"
+	"goyave.dev/goyave/v5/config"
+	"goyave.dev/goyave/v5/util/testutil"
+)
+
+func TestZstdEncoder(t *testing.T) {
+	encoder := &Zstd{
+		Options: nil,
+	}
+
+	assert.Equal(t, "zstd", encoder.Encoding())
+
+	buf := bytes.NewBuffer([]byte{})
+	writer := encoder.NewWriter(buf)
+	if assert.NotNil(t, writer) {
+		_, ok := writer.(*zstd.Encoder)
+		assert.True(t, ok)
+	}
+
+	assert.Panics(t, func() {
+		// Invalid EncoderConcurrency
+		encoder := &Zstd{
+			Options: []zstd.EOption{
+				zstd.WithEncoderConcurrency(0),
+			},
+		}
+		encoder.NewWriter(bytes.NewBuffer([]byte{}))
+	})
+}
+
+func TestZstdCompression(t *testing.T) {
+	server := testutil.NewTestServerWithOptions(t, goyave.Options{Config: config.LoadDefault()})
+
+	handler := func(resp *goyave.Response, _ *goyave.Request) {
+		resp.Header().Set("Content-Length", "1234")
+		resp.String(http.StatusOK, "hello world")
+	}
+
+	compressMiddleWare := &Middleware{
+		Encoders: []Encoder{
+			&Zstd{
+				Options: []zstd.EOption{
+					zstd.WithEncoderConcurrency(1),
+					zstd.WithEncoderCRC(true),
+				},
+			},
+		},
+	}
+
+	request := testutil.NewTestRequest(http.MethodGet, "/zstd", nil)
+	request.Header().Set("Accept-Encoding", "zstd")
+	result := server.TestMiddleware(compressMiddleWare, request, handler)
+
+	reader, _ := zstd.NewReader(result.Body)
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.NoError(t, result.Body.Close())
+	assert.Equal(t, "hello world", string(body))
+	assert.Equal(t, "zstd", result.Header.Get("Content-Encoding"))
+	assert.Empty(t, result.Header.Get("Content-Length"))
+}


### PR DESCRIPTION
Issue(s): #197, #198, #199, #200

This pull request provides new Encoders for the Goyave compress middleware using the following algorithms:
- Zlib (deflate)
- LZW
- Brotli
- Zstd

Tests and comments are included