### PR TITLE
#221 Auth: Fix JWT controller gorm.ErrRecordNotFound handling

### DIFF
--- a/auth/jwt_controller.go
+++ b/auth/jwt_controller.go
@@ -116,6 +116,11 @@ func (c *JWTController[T]) Login(response *goyave.Response, request *goyave.Requ
 		return
 	}
 
+	if notFound {
+		response.JSON(http.StatusUnauthorized, map[string]string{"error": request.Lang.Get("auth.invalid-credentials")})
+		return
+	}
+
 	t := reflect.Indirect(reflect.ValueOf(user))
 	for t.Kind() == reflect.Ptr {
 		t = t.Elem()
@@ -126,7 +131,7 @@ func (c *JWTController[T]) Login(response *goyave.Response, request *goyave.Requ
 		return
 	}
 
-	if !notFound && bcrypt.CompareHashAndPassword([]byte(pass.String()), []byte(password)) == nil {
+	if bcrypt.CompareHashAndPassword([]byte(pass.String()), []byte(password)) == nil {
 		tokenFunc := lo.Ternary(c.TokenFunc == nil, c.defaultTokenFunc, c.TokenFunc)
 		token, err := tokenFunc(request, user)
 		if err != nil {


### PR DESCRIPTION
## References

**Issue(s):** #221 

## Description

<!-- Make a clear and detailed description of your changes, with the added benefits and motivations. -->

<!-- If your pull request is functional (new utilities or middleware for example), **include some usage examples**. -->
Fixed a reflection error in the Login handler of the JWT Controller. If the user service returns `gorm.ErrRecordNotFound`, a `401 Unauthorized` response will be returned.

