### PR TITLE
#228 - Feat: create slog discard logger

### DIFF
--- a/slog/slog.go
+++ b/slog/slog.go
@@ -3,6 +3,7 @@ package slog
 import (
 	"context"
 	"fmt"
+	"io"
 	"reflect"
 	"runtime"
 	"time"
@@ -191,4 +192,9 @@ func structValue(v reflect.Value) slog.Value {
 		return slog.AnyValue(v.Interface())
 	}
 	return slog.GroupValue(attrs...)
+}
+
+// DiscardLogger returns a new Logger that discards all logs.
+func DiscardLogger() *Logger {
+	return &Logger{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
 }

--- a/slog/slog_test.go
+++ b/slog/slog_test.go
@@ -176,4 +176,12 @@ func TestLogger(t *testing.T) {
 		l.ErrorWithSource(context.Background(), pc, err)
 		assert.Regexp(t, r, buf.String())
 	})
+
+	t.Run("DiscardLogger", func(t *testing.T) {
+		logger := DiscardLogger()
+
+		assert.NotPanics(t, func() {
+			logger.Info("This log should be discarded")
+		})
+	})
 }

--- a/util/testutil/testutil.go
+++ b/util/testutil/testutil.go
@@ -69,7 +69,7 @@ func NewTestServer(t *testing.T, configFileName string) *TestServer {
 // routes without starting the server.
 //
 // By default, if no `Logger` is given in the options, a default logger redirecting the
-// output to `testing.T.Log()` is used.
+// output to `io.Discard` is used.
 //
 // Automatically closes the DB connection (if there is one) using a test `Cleanup` function.
 func NewTestServerWithOptions(t *testing.T, opts goyave.Options) *TestServer {
@@ -82,7 +82,7 @@ func NewTestServerWithOptions(t *testing.T, opts goyave.Options) *TestServer {
 	}
 
 	if opts.Logger == nil {
-		opts.Logger = slog.New(slog.NewHandler(opts.Config.GetBool("app.debug"), &LogWriter{t: t}))
+		opts.Logger = slog.DiscardLogger()
 	}
 
 	srv, err := goyave.New(opts)

--- a/util/testutil/testutil_test.go
+++ b/util/testutil/testutil_test.go
@@ -34,7 +34,7 @@ func TestTestServer(t *testing.T) {
 	t.Run("NewTestServer", func(t *testing.T) {
 		server := NewTestServer(t, "resources/custom_config.json")
 		assert.Equal(t, "value", server.Config().Get("custom-entry"))
-		assert.Equal(t, slog.New(slog.NewHandler(true, &LogWriter{t: t})), server.Logger)
+		assert.Equal(t, slog.DiscardLogger(), server.Logger)
 	})
 
 	t.Run("NewTestServerWithOptions", func(t *testing.T) {
@@ -45,7 +45,7 @@ func TestTestServer(t *testing.T) {
 
 		assert.NotNil(t, server.Lang)
 		assert.Equal(t, "test-value", server.Config().Get("test-entry"))
-		assert.Equal(t, slog.New(slog.NewHandler(true, &LogWriter{t: t})), server.Logger)
+		assert.Equal(t, slog.DiscardLogger(), server.Logger)
 	})
 
 	t.Run("NewTestServer_AutoConfig", func(t *testing.T) {


### PR DESCRIPTION
## References

**Issue(s):** #228  <!-- List all related issues here, use keywords if necessary: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->  
**Discussion:**  no discussion

## Description

Created the logger with `io.Discard` and set it as the default in NewTestServerWithOptions if no logger is provided as a parameter.

### Possible drawbacks

<!-- Describe the possible drawbacks and caveats of your changes here. If there are none, you can remove this section. -->


I noticed that `io.Discard` is already used [here in log_bench_test.go](https://github.com/go-goyave/goyave/blob/2ce8e01d18639caf00098200b28d973b2420d7b4/log/log_bench_test.go#L17) in a `slog.NewHandler`. In the implementation of `slog.Discard` I chose to use `slog.NewTextHandler` because I understand that it achieves the same objective, however it is more evident that it is a text.