### PR TITLE
fix(util):  add escape system so '*', '[]' can be escaped

### DIFF
--- a/util/walk/walk_test.go
+++ b/util/walk/walk_test.go
@@ -232,6 +232,54 @@ func TestParse(t *testing.T) {
 	path, err = Parse(".invalid[]path")
 	assert.Nil(t, path)
 	require.Error(t, err)
+
+}
+
+func TestEscapedParse(t *testing.T) {
+	path, err := Parse(`object\*field`)
+	require.NoError(t, err)
+	assert.Equal(t, &Path{
+		Name: strPtr("object*field"),
+		Type: PathTypeElement,
+		Next: nil,
+	}, path)
+
+	path, err = Parse("array[][].field\\[]")
+	require.NoError(t, err)
+	assert.Equal(t, &Path{
+		Name: strPtr("array"),
+		Type: PathTypeArray,
+		Next: &Path{
+			Type: PathTypeArray,
+			Next: &Path{
+				Type: PathTypeObject,
+				Next: &Path{
+					Name: strPtr("field[]"),
+					Type: PathTypeElement,
+					Next: nil,
+				},
+			},
+		},
+	}, path)
+
+	path, err = Parse("array[][].field\\[tx\\]")
+	require.NoError(t, err)
+	assert.Equal(t, &Path{
+		Name: strPtr("array"),
+		Type: PathTypeArray,
+		Next: &Path{
+			Type: PathTypeArray,
+			Next: &Path{
+				Type: PathTypeObject,
+				Next: &Path{
+					Name: strPtr("field[tx]"),
+					Type: PathTypeElement,
+					Next: nil,
+				},
+			},
+		},
+	}, path)
+
 }
 
 func TestMustParse(t *testing.T) {


### PR DESCRIPTION


## References

**Issue(s):** #205

## Description

Add escape system to enable `walk.Path` to use `*`  `[` `]` in paths 

Examples:
- `object\*field`
- `array[][].field\\[]`
- `array[][].field\\[tx\\]`


