### PR TITLE
typeutil: Undefined improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.23", "1.24"]
+        go: ["1.24"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/util/typeutil/undefined.go
+++ b/util/typeutil/undefined.go
@@ -46,6 +46,20 @@ func NewUndefined[T any](val T) Undefined[T] {
 	}
 }
 
+// Set the value. Automatically sets `Present` to `true`.
+func (u *Undefined[T]) Set(value T) {
+	u.Val = value
+	u.Present = true
+}
+
+// Unset the value (reset to zero-value) and set `Present` to `false`.
+// This effectively works like if the value was entirely removed from the struct.
+func (u *Undefined[T]) Unset() {
+	var v T
+	u.Val = v
+	u.Present = false
+}
+
 // UnmarshalJSON implements json.Unmarshaler.
 // On successful unmarshal of the underlying value, sets the `Present` field to `true`.
 func (u *Undefined[T]) UnmarshalJSON(data []byte) error {

--- a/util/typeutil/undefined_test.go
+++ b/util/typeutil/undefined_test.go
@@ -63,6 +63,36 @@ func TestUndefined(t *testing.T) {
 		assert.Equal(t, &Undefined[int64]{Val: 0, Present: false}, u)
 	})
 
+	t.Run("MarshalJSON", func(t *testing.T) {
+		uInt := NewUndefined[int64](1234)
+
+		data, err := json.Marshal(uInt)
+		require.NoError(t, err)
+		assert.Equal(t, "1234", string(data))
+
+		uStr := NewUndefined("hello")
+		data, err = json.Marshal(uStr)
+		require.NoError(t, err)
+		assert.Equal(t, `"hello"`, string(data))
+
+		uChan := NewUndefined(make(chan struct{}))
+		_, err = json.Marshal(uChan)
+		require.Error(t, err)
+		close(uChan.Val)
+
+		type testStrct struct {
+			Optional Undefined[string] `json:"optional,omitzero"`
+		}
+
+		data, err = json.Marshal(testStrct{})
+		require.NoError(t, err)
+		assert.Equal(t, "{}", string(data))
+
+		data, err = json.Marshal(testStrct{Optional: NewUndefined("hello")})
+		require.NoError(t, err)
+		assert.Equal(t, `{"optional":"hello"}`, string(data))
+	})
+
 	t.Run("UnmarshalText", func(t *testing.T) {
 		u := &Undefined[int64]{} // Not a text unmarshaler
 		require.Error(t, u.UnmarshalText([]byte("123456789")))

--- a/util/typeutil/undefined_test.go
+++ b/util/typeutil/undefined_test.go
@@ -52,6 +52,22 @@ func TestUndefined(t *testing.T) {
 		assert.Equal(t, Undefined[string]{Val: "hello", Present: true}, u)
 	})
 
+	t.Run("Set", func(t *testing.T) {
+		u := Undefined[string]{}
+		u.Set("hello")
+		assert.Equal(t, Undefined[string]{Val: "hello", Present: true}, u)
+	})
+
+	t.Run("Unset", func(t *testing.T) {
+		u := NewUndefined("hello")
+		u.Unset()
+		assert.Equal(t, Undefined[string]{}, u)
+
+		uPtr := NewUndefined(lo.ToPtr("hello"))
+		uPtr.Unset()
+		assert.Equal(t, Undefined[*string]{}, uPtr)
+	})
+
 	t.Run("UnmarshalJSON", func(t *testing.T) {
 		u := &Undefined[int64]{}
 


### PR DESCRIPTION
## References

**Issue(s):** none
**Discussion:** none

## Description

- With the introduction of the json `omitzero` tag in [Go 1.24](https://tip.golang.org/doc/go1.24), the `typeutil.Undefined` type can be improved to support json marshaling. If used in combination with the `omitzero` tag, the marshaling behavior will be as expected for a non-present field.
- Adds the `Set` and `Unset` convenience methods.
- Improves documentation of the `typeutil.Undefined` type.
- Handle more cases in the `Scan()` implementation
  - If the `src` is also an `Undefined` (or `*Undefined`) of the same `T`, use its `Val` directly
  - If `src` is nil, set the `Val` to `T`'s zero value
  - Prevent nil dereferences if the `src` is a pointer. Use `T`'s zero value instead and still consider the field as present. The idea is to always consider the field as present because if it's not, the `Scan()` method should never be called in the first place.
  - Use `sql.Scanner` implementation as last resort instead of first 
- These changes open up the ability to use `typeutil.Undefined` for responses while it was limited to requests before. One could work around this by carefully tweaking the `omitempty` struct tag and using pointers, but that is inconvenient, error-prone and generally unsafe. With this solution, the doubt is removed: if the field type is `Undefined` and there is the `omitzero` struct tag, everything will work as expected, always.

### Possible drawbacks

Marshal output will be different since it will only output the value, not the entire struct. Repeatedly marshaling/unmarshaling the same struct will still work exactly like before.

Because `omitzero` is only supported since go 1.24, the behavior with go 1.23 will be partly incorrect. However, this incorrect behavior will be identical when using go 1.24 and forgetting to set `omitzero`.

**Known issue**: `Scan()` may return an "incompatible types" error if `T` is a pointer to a type implementing `sql.Scanner` and `src` has a different type. This is because when type-asserting the `Val`, we first dereference it, resulting in a double pointer. I currently do not have a clean solution for this, and I would like to avoid using reflection. This is minor because I don't think this specific use-case is frequent at all.

