### PR TITLE
Validation: add exported Init to Validator interface #239

### DIFF
--- a/validation/ruleset.go
+++ b/validation/ruleset.go
@@ -21,7 +21,12 @@ type Ruler interface {
 // scoped to a single field validation in a single request.
 type Validator interface {
 	Composable
+
+	// init unexported method to force compositing with `BaseValidator`.
 	init(opts *Options)
+
+	// Init the validator with the resources required by the `Composable` interface.
+	Init(opts *Options)
 
 	// Validate checks the field under validation satisfies this validator's criteria.
 	// If necessary, replaces the `Context.Value` with a converted value (see `IsType()`).
@@ -65,6 +70,11 @@ func (v *BaseValidator) init(options *Options) {
 		lang:   options.Language,
 		logger: options.Logger,
 	}
+}
+
+// Init the validator with the resources required by the `Composable` interface.
+func (v *BaseValidator) Init(options *Options) {
+	v.init(options)
 }
 
 // IsTypeDependent returns false.

--- a/validation/ruleset_test.go
+++ b/validation/ruleset_test.go
@@ -4,6 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+	"goyave.dev/goyave/v5/config"
+	"goyave.dev/goyave/v5/lang"
+	"goyave.dev/goyave/v5/slog"
 	"goyave.dev/goyave/v5/util/walk"
 )
 
@@ -280,4 +284,24 @@ func TestRulesetRequired(t *testing.T) {
 func TestRules(t *testing.T) {
 	rules := Rules{{}, {}}
 	assert.Equal(t, rules, rules.AsRules())
+}
+
+func TestBaseValidator(t *testing.T) {
+	v := &BaseValidator{}
+
+	opts := &Options{
+		DB:       &gorm.DB{},
+		Config:   &config.Config{},
+		Language: lang.Default,
+		Logger:   &slog.Logger{},
+	}
+	v.Init(opts)
+	assert.Same(t, opts.DB, v.db)
+	assert.Same(t, opts.Config, v.config)
+	assert.Same(t, opts.Language, v.lang)
+	assert.Same(t, opts.Logger, v.logger)
+
+	assert.False(t, v.IsTypeDependent())
+	assert.False(t, v.IsType())
+	assert.Equal(t, []string{}, v.MessagePlaceholders(nil))
 }

--- a/validation/unique_test.go
+++ b/validation/unique_test.go
@@ -126,7 +126,7 @@ func TestUniqueValidator(t *testing.T) {
 			v := Unique(func(db *gorm.DB, val any) *gorm.DB {
 				return db.Model(&uniqueTestModel{}).Where(c.column, val)
 			})
-			v.init(opts)
+			v.Init(opts)
 
 			ctx := &Context{
 				Invalid: !c.valid,
@@ -215,7 +215,7 @@ func TestExistsValidator(t *testing.T) {
 			v := Exists(func(db *gorm.DB, val any) *gorm.DB {
 				return db.Model(&uniqueTestModel{}).Where(c.column, val)
 			})
-			v.init(opts)
+			v.Init(opts)
 
 			ctx := &Context{
 				Invalid: !c.valid,
@@ -347,7 +347,7 @@ func TestUniqueArrayValidator(t *testing.T) {
 			}
 
 			v := UniqueArray[int](c.table, c.column, c.transform)
-			v.init(opts)
+			v.Init(opts)
 
 			ctx := &Context{
 				Invalid: !c.valid,
@@ -376,7 +376,7 @@ func TestUniqueArrayValidator(t *testing.T) {
 				opts := prepareUniqueTest(t)
 				opts.Config.Set("database.connection", c.dialect)
 				v := UniqueArray[int]("models", "name", nil)
-				v.init(opts)
+				v.Init(opts)
 
 				tx, _ := v.buildQuery([]int{2, 7, 6}, false)
 
@@ -509,7 +509,7 @@ func TestExistsArrayValidator(t *testing.T) {
 			}
 
 			v := ExistsArray[int](c.table, c.column, c.transform)
-			v.init(opts)
+			v.Init(opts)
 
 			ctx := &Context{
 				Invalid: !c.valid,
@@ -538,7 +538,7 @@ func TestExistsArrayValidator(t *testing.T) {
 				opts := prepareUniqueTest(t)
 				opts.Config.Set("database.connection", c.dialect)
 				v := ExistsArray[int]("models", "name", nil)
-				v.init(opts)
+				v.Init(opts)
 
 				tx, _ := v.buildQuery([]int{2, 7, 6}, true)
 
@@ -572,7 +572,7 @@ func TestBuildQueryValidatorWithTransform(t *testing.T) {
 					return gorm.Expr("?", val-1)
 				}
 				v := ExistsArray[int]("models", "name", transform)
-				v.init(opts)
+				v.Init(opts)
 
 				tx, _ := v.buildQuery([]int{2, 7, 6}, true)
 
@@ -589,7 +589,7 @@ func TestClickhouseUnsupportedType(t *testing.T) {
 	opts := prepareUniqueTest(t)
 	opts.Config.Set("database.connection", "clickhouse")
 	v := ExistsArray[struct{}]("models", "name", nil)
-	v.init(opts)
+	v.Init(opts)
 
 	ctx := &Context{
 		Value: []struct{}{{}, {}},

--- a/validation/validator.go
+++ b/validation/validator.go
@@ -388,7 +388,7 @@ func (v *validator) validateField(fieldName string, field *Field, walkData any, 
 				path:      errorPath,
 				Invalid:   !valid,
 			}
-			validator.init(v.options)
+			validator.Init(v.options)
 			ok := validator.Validate(ctx)
 			if len(ctx.errors) > 0 {
 				valid = false


### PR DESCRIPTION
## References

**Issue(s):** closes #239

## Description

- Added an unexported `Init()` method on `validation.Validator` and implement it in `BaseValidator`.
  - This allows initializing a `Validator` inside tests.
  - This method can be overridden by developers in custom validators in case some additional custom values must be defined at initialization.
- The composition with `BaseValidator` is still mandatory. This decision was initially made to promote a simpler and shorter syntax for custom validator, by taking advantage of method overriding.

### Possible drawbacks

None.

