### PR TITLE
Validation: fix illegal path syntax error with composition

### DIFF
--- a/validation/ruleset.go
+++ b/validation/ruleset.go
@@ -136,7 +136,7 @@ func (r RuleSet) asRulesWithPrefix(prefix string) Rules {
 	for _, field := range sortedRuleSet {
 		path := prefix
 		if field.Path != CurrentElement {
-			if strings.HasPrefix("[]", field.Path) || path == "" {
+			if strings.HasPrefix(field.Path, "[]") || path == "" {
 				path += field.Path
 			} else {
 				path += "." + field.Path

--- a/validation/ruleset_test.go
+++ b/validation/ruleset_test.go
@@ -114,12 +114,27 @@ func TestRuleset(t *testing.T) {
 			{Path: "[]", Rules: List{Int()}},
 		}},
 
+		{Path: "array_of_objects_composition", Rules: RuleSet{
+			{Path: CurrentElement, Rules: List{Array()}},
+			{Path: "[]", Rules: List{Object()}},
+			{Path: "[].field", Rules: List{String()}},
+		}},
+
 		{Path: "array_element_composition", Rules: RuleSet{
 			{Path: CurrentElement, Rules: List{Array()}},
 			{Path: "[]", Rules: RuleSet{
 				{Path: CurrentElement, Rules: List{Int()}},
 			}},
 		}},
+
+		{Path: "array_object_element_composition", Rules: RuleSet{
+			{Path: CurrentElement, Rules: List{Array()}},
+			{Path: "[]", Rules: RuleSet{
+				{Path: CurrentElement, Rules: List{Object()}},
+				{Path: "field", Rules: List{String()}},
+			}},
+		}},
+
 		{Path: "deep_array_element_composition", Rules: RuleSet{
 			{Path: CurrentElement, Rules: List{Array()}},
 			{Path: "[]", Rules: RuleSet{
@@ -228,12 +243,46 @@ func TestRuleset(t *testing.T) {
 			isArray:     true,
 		},
 		{
+			Path:       walk.MustParse("array_of_objects_composition"),
+			Validators: []Validator{Array()},
+			Elements: &Field{
+				Path:        walk.MustParse("[]"),
+				Validators:  []Validator{Object()},
+				prefixDepth: 1,
+				isObject:    true,
+			},
+			prefixDepth: 1,
+			isArray:     true,
+		},
+		{
+			Path:        walk.MustParse("array_of_objects_composition[].field"),
+			Validators:  []Validator{String()},
+			prefixDepth: 1,
+		},
+		{
 			Path:       walk.MustParse("array_element_composition"),
 			Validators: []Validator{Array()},
 			Elements: &Field{
 				Path:        walk.MustParse("[]"),
 				Validators:  []Validator{Int()},
 				prefixDepth: 2,
+			},
+			prefixDepth: 1,
+			isArray:     true,
+		},
+		{
+			Path:        walk.MustParse("array_object_element_composition[].field"),
+			Validators:  []Validator{String()},
+			prefixDepth: 2,
+		},
+		{
+			Path:       walk.MustParse("array_object_element_composition"),
+			Validators: []Validator{Array()},
+			Elements: &Field{
+				Path:        walk.MustParse("[]"),
+				Validators:  []Validator{Object()},
+				prefixDepth: 2,
+				isObject:    true,
 			},
 			prefixDepth: 1,
 			isArray:     true,


### PR DESCRIPTION
## References

None.

## Description

Fixed "illegal syntax" error when using ruleset composition for an array of objects. Example:
```go
func SomeValidation(r *goyave.Request) v.RuleSet {
	return v.RuleSet{
		{Path: v.CurrentElement, Rules: v.List{v.Object()}},
		{Path: "someArray", Rules: CompositionValidation(r)}},
	}
}

func CompositionValidation(_ *goyave.Request) v.RuleSet {
	return v.RuleSet{
		{Path: v.CurrentElement, Rules: v.List{v.Array()}},
		{Path: "[]", Rules: v.List{v.Object()}},
		{Path: "[].field", Rules: v.List{v.Required(), v.String()}},
	}
}
```
This would result in the following error before the fix:
```
illegal syntax: "someArray.[].field"
```

The path that should be actually generated is `someArray[].field` (without the extra dot before the brackets).

### Possible drawbacks

None.

