### PR TITLE
validation: add OnlyIfValidator

### DIFF
--- a/validation/only_if.go
+++ b/validation/only_if.go
@@ -1,0 +1,35 @@
+package validation
+
+// OnlyIfValidator execute a validator only if a condition is met.
+type OnlyIfValidator struct {
+	Validator
+	Condition func(*Context) bool
+}
+
+// Validate executes the embedded validator only if the Condition returns true.
+// Otherwise immediately returns true.
+func (v *OnlyIfValidator) Validate(ctx *Context) bool {
+	if !v.Condition(ctx) {
+		return true
+	}
+	return v.Validator.Validate(ctx)
+}
+
+// OnlyIf execute the given Validator only if the condition returns true.
+// This enables conditional validation.
+//
+// For example, if you want a validator to be executed only if another boolean field
+// is "true":
+//
+//	  v.OnlyIf(func(ctx *v.Context) bool {
+//		  other := walk.MustParse("other").First(ctx.Data)
+//		  return other.Value == true
+//	  }, MyValidator())
+//
+// This CANNOT be used with `Required()`, `RequiredIf()`, `Nullable()` or any type validator.
+func OnlyIf(condition func(*Context) bool, validator Validator) *OnlyIfValidator {
+	return &OnlyIfValidator{
+		Validator: validator,
+		Condition: condition,
+	}
+}

--- a/validation/only_if_test.go
+++ b/validation/only_if_test.go
@@ -1,0 +1,49 @@
+package validation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func alwaysTrue(_ *Context) bool {
+	return true
+}
+
+func alwaysFalse(_ *Context) bool {
+	return false
+}
+
+func TestOnlyIfValidator(t *testing.T) {
+	t.Run("Constructor", func(t *testing.T) {
+		v := OnlyIf(alwaysTrue, Min(1))
+		assert.NotNil(t, v)
+		// Validator implementation should be "inherited"
+		// thanks to composition.
+		assert.Equal(t, "min", v.Name())
+		assert.False(t, v.IsType())
+		assert.True(t, v.IsTypeDependent())
+		assert.Equal(t, []string{":min", "1"}, v.MessagePlaceholders(&Context{}))
+	})
+
+	cases := []struct {
+		value     any
+		validator Validator
+		condition func(*Context) bool
+		desc      string
+		want      bool
+	}{
+		{desc: "condition_true", validator: Max(3), condition: alwaysTrue, value: "string", want: false},
+		{desc: "condition_false", validator: Max(3), condition: alwaysFalse, value: "string", want: true}, // true because Max shouldn't be executed.
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("Validate_%s", c.desc), func(t *testing.T) {
+			v := OnlyIf(c.condition, c.validator)
+			assert.Equal(t, c.want, v.Validate(&Context{
+				Value: c.value,
+			}))
+		})
+	}
+}


### PR DESCRIPTION
## References

**Issue(s):** closes #245 

## Description

Added the `OnlyIf` wrapper validator, which enables conditional validation for complex use-cases. The validation message, placeholders and other data from the wrapped validator are kept and "inherited" automatically.

For example, if you want a validator to be executed only if another boolean field is "true":
```go
v.OnlyIf(func(ctx *v.Context) bool {
	other := walk.MustParse("other").First(ctx.Data)
	return other.Value == true
}, MyValidator())
```

### Possible drawbacks

This validator cannot be used with `Required()`, `RequiredIf()`, `Nullable()` or any type validator validators. Using it with these validators may lead to buggy behavior. This use-case shouldn't be encouraged anyway as it would make the request body difficult to use and convert to a DTO afterwards.

