### PR TITLE
Validation: add WithMessage

### DIFF
--- a/lang/lang_test.go
+++ b/lang/lang_test.go
@@ -97,8 +97,9 @@ func (suite *LangTestSuite) TestLoad() {
 		},
 		validation: validationLines{
 			rules: map[string]string{
-				"override":       "rule override",
-				"required.array": "The :field values are required.",
+				"override":        "rule override",
+				"required.array":  "The :field values are required.",
+				"messageOverride": "Custom error message: placeholders work: ':field', :min - :max",
 			},
 			fields: map[string]string{
 				"email": "email address",

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -245,8 +245,8 @@ func TestLanguageMiddleware(t *testing.T) {
 }
 
 type testValidator struct {
-	validation.BaseValidator
 	validateFunc func(c *testValidator, ctx *validation.Context) bool
+	validation.BaseValidator
 }
 
 func (v *testValidator) Validate(ctx *validation.Context) bool {

--- a/resources/lang/en-US/rules.json
+++ b/resources/lang/en-US/rules.json
@@ -1,4 +1,5 @@
 {
     "override": "rule override",
-    "required.array": "The :field values are required."
+    "required.array": "The :field values are required.",
+    "messageOverride": "Custom error message: placeholders work: ':field', :min - :max"
 }

--- a/validation/comparison.go
+++ b/validation/comparison.go
@@ -16,8 +16,8 @@ import (
 //   - Compare the number of keys in an object with a numeric field
 //   - Compare a file (or multifile) size with a numeric field. The number of KiB of each file is rounded up (ceil).
 type ComparisonValidator struct {
-	BaseValidator
 	Path *walk.Path
+	BaseValidator
 }
 
 // Validate checks the field under validation satisfies this validator's criteria.

--- a/validation/date.go
+++ b/validation/date.go
@@ -62,8 +62,8 @@ func Date(acceptedFormats ...string) *DateValidator {
 
 // DateComparisonValidator factorized date comparison validator for static dates (before, after, etc.)
 type DateComparisonValidator struct {
-	BaseValidator
 	Date time.Time
+	BaseValidator
 }
 
 func (v *DateComparisonValidator) validate(ctx *Context, comparisonFunc func(time.Time, time.Time) bool) bool {
@@ -85,8 +85,8 @@ func (v *DateComparisonValidator) MessagePlaceholders(_ *Context) []string {
 
 // DateFieldComparisonValidator factorized date comparison validator for field dates (before field, after field, etc.)
 type DateFieldComparisonValidator struct {
-	BaseValidator
 	Path *walk.Path
+	BaseValidator
 }
 
 func (v *DateFieldComparisonValidator) validate(ctx *Context, comparisonFunc func(time.Time, time.Time) bool) bool {

--- a/validation/different.go
+++ b/validation/different.go
@@ -14,8 +14,8 @@ import (
 // For numbers, make sure the two compared numbers have the same type. A `uint` with value `1` will be considered
 // different from an `int` with value `1`.
 type DifferentValidator struct {
-	BaseValidator
 	Path *walk.Path
+	BaseValidator
 }
 
 // Validate checks the field under validation satisfies this validator's criteria.

--- a/validation/in.go
+++ b/validation/in.go
@@ -83,8 +83,8 @@ func NotIn[T comparable](values []T) *NotInValidator[T] {
 // InFieldValidator validates the field under validation must be in at least one
 // of the arrays matched by the specified path.
 type InFieldValidator[T comparable] struct {
-	BaseValidator
 	Path *walk.Path
+	BaseValidator
 }
 
 // Validate checks the field under validation satisfies this validator's criteria.

--- a/validation/regex.go
+++ b/validation/regex.go
@@ -5,8 +5,8 @@ import "regexp"
 // RegexValidator the field under validation must be a string matching
 // the specified `*regexp.Regexp`.
 type RegexValidator struct {
-	BaseValidator
 	Regexp *regexp.Regexp
+	BaseValidator
 }
 
 // Validate checks the field under validation satisfies this validator's criteria.

--- a/validation/required.go
+++ b/validation/required.go
@@ -36,8 +36,8 @@ func Required() *RequiredValidator {
 // RequiredIfValidator is the same as `RequiredValidator` but only applies the behavior
 // described if the specified `Condition` function returns true.
 type RequiredIfValidator struct {
-	RequiredValidator
 	Condition func(*Context) bool
+	RequiredValidator
 }
 
 // Validate checks the field under validation satisfies this validator's criteria.

--- a/validation/ruleset.go
+++ b/validation/ruleset.go
@@ -55,12 +55,16 @@ type Validator interface {
 	// This is use to generate the validation error message. An empty slice can be returned.
 	// See `lang.Language.Get()` for more details.
 	MessagePlaceholders(ctx *Context) []string
+
+	overrideMessage(langEntry string)
+	getMessageOverride() string
 }
 
 // BaseValidator composable structure that implements the basic functions required to
 // satisfy the `Validator` interface.
 type BaseValidator struct {
 	component
+	messageOverride string
 }
 
 func (v *BaseValidator) init(options *Options) {
@@ -85,6 +89,22 @@ func (v *BaseValidator) IsType() bool { return false }
 
 // MessagePlaceholders returns an empty slice (no placeholders)
 func (v *BaseValidator) MessagePlaceholders(_ *Context) []string { return []string{} }
+
+func (v *BaseValidator) overrideMessage(langEntry string) {
+	v.messageOverride = langEntry
+}
+
+func (v *BaseValidator) getMessageOverride() string {
+	return v.messageOverride
+}
+
+// WithMessage set a custom language entry for the error message of a Validator.
+// Original placeholders returned by the validator are still used to render the message.
+// Type-dependent and "element" suffixes are not added when the message is overridden.
+func WithMessage[V Validator](v V, langEntry string) V {
+	v.overrideMessage(langEntry)
+	return v
+}
 
 // FieldRulesConverter types implementing this interface define their behavior
 // when converting a `FieldRules` to `Rules`. This enables rule sets composition.

--- a/validation/same.go
+++ b/validation/same.go
@@ -14,8 +14,8 @@ import (
 // For numbers, make sure the two compared numbers have the same type. A `uint` with value `1` will be considered
 // different from an `int` with value `1`.
 type SameValidator struct {
-	BaseValidator
 	Path *walk.Path
+	BaseValidator
 }
 
 // Validate checks the field under validation satisfies this validator's criteria.

--- a/validation/unique.go
+++ b/validation/unique.go
@@ -41,8 +41,8 @@ var clickhouseTypes = map[reflect.Type]string{
 // UniqueValidator validates the field under validation must have a unique value in database
 // according to the provided database scope. Uniqueness is checked using a COUNT query.
 type UniqueValidator struct {
-	BaseValidator
 	Scope func(db *gorm.DB, val any) *gorm.DB // TODO v6: change val to validation.Context
+	BaseValidator
 }
 
 // Validate checks the field under validation satisfies this validator's criteria.

--- a/validation/validator.go
+++ b/validation/validator.go
@@ -485,6 +485,10 @@ func (v *validator) processAddedErrors(ctx *Context, parentPath *walk.Path, c *w
 }
 
 func (v *validator) getLangEntry(ctx *Context, validator Validator) string {
+	override := validator.getMessageOverride()
+	if override != "" {
+		return override
+	}
 	langEntry := "validation.rules." + validator.Name()
 	if validator.IsTypeDependent() {
 		typeValidator := v.findTypeValidator(ctx.Field.Validators)


### PR DESCRIPTION
## References

**Issue(s):** closes #250

## Description

- Added `validation.WithMessage()` function, which overrides the language entry used to render the error message of a validator.
  - Original placeholders returned by the validator are still used to render the message.
  - Type-dependent and "element" suffixes are not added when the message is overridden. 

**Example usage:**
```go
func (ctrl *Controller) UpdateRequest(_ *goyave.Request) v.RuleSet {
	return v.RuleSet{
		//...
		{Path: "contents", Rules: v.List{v.WithMessage(v.String(), "validation.rules.custom"), v.Min(10)}},
	}
}
```

### Possible drawbacks

The `WithMessage` syntax is not the cleanest. However, using a method instead wouldn't be possible because it would need to return itself, which wouldn't be possible with composition.

