### PR TITLE
fix: the MIME type of an SVG file should be image/svg+xml

### DIFF
--- a/util/fsutil/file.go
+++ b/util/fsutil/file.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"mime/multipart"
-	"net/http"
 	"os"
 	"sync"
 
@@ -143,19 +142,16 @@ func (file *File) Save(fs WritableFS, path string, name string) (filename string
 func ParseMultipartFiles(headers []*multipart.FileHeader) ([]File, error) {
 	files := []File{}
 	for _, fh := range headers {
-		fileHeader := make([]byte, 512)
+		mimeType := "application/octet-stream"
 
 		if fh.Size != 0 {
 			f, err := fh.Open()
 			if err != nil {
 				return nil, errors.New(err)
 			}
-			if _, err := f.Read(fileHeader); err != nil {
-				_ = f.Close()
-				return nil, errors.New(err)
-			}
 
-			if _, err := f.Seek(0, 0); err != nil {
+			mimeType, err = DetectContentType(f, fh.Filename)
+			if err != nil {
 				_ = f.Close()
 				return nil, errors.New(err)
 			}
@@ -166,7 +162,7 @@ func ParseMultipartFiles(headers []*multipart.FileHeader) ([]File, error) {
 
 		file := File{
 			Header:   fh,
-			MIMEType: http.DetectContentType(fileHeader),
+			MIMEType: mimeType,
 		}
 		files = append(files, file)
 	}

--- a/util/fsutil/file.go
+++ b/util/fsutil/file.go
@@ -150,7 +150,7 @@ func ParseMultipartFiles(headers []*multipart.FileHeader) ([]File, error) {
 				return nil, errors.New(err)
 			}
 
-			mimeType, err = DetectContentType(f, fh.Filename)
+			mimeType, err = DetectContentType(f, "")
 			if err != nil {
 				_ = f.Close()
 				return nil, errors.New(err)

--- a/util/fsutil/fsutil.go
+++ b/util/fsutil/fsutil.go
@@ -149,10 +149,26 @@ func DetectContentType(r io.Reader, fileName string) (string, error) {
 }
 
 func hasSVGSignature(buffer []byte) bool {
-	content := strings.TrimSpace(strings.ToLower(string(buffer)))
-	if after, ok := strings.CutPrefix(content, "\ufeff"); ok {
-		content = strings.TrimSpace(after)
+	start := -1
+	for i, b := range buffer {
+		if b == '<' {
+			start = i
+			break
+		}
 	}
+	if start == -1 {
+		return false
+	}
+
+	raw := buffer[start:]
+	normalized := make([]byte, 0, len(raw))
+	for _, b := range raw {
+		if b != 0 {
+			normalized = append(normalized, b)
+		}
+	}
+
+	content := strings.TrimSpace(strings.ToLower(string(normalized)))
 
 	// Skip possible comments
 	for {

--- a/util/fsutil/fsutil.go
+++ b/util/fsutil/fsutil.go
@@ -154,6 +154,7 @@ func hasSVGSignature(buffer []byte) bool {
 		content = strings.TrimSpace(after)
 	}
 
+	// Skip possible comments
 	for {
 		if strings.HasPrefix(content, "<?xml") {
 			end := strings.Index(content, "?>")

--- a/util/fsutil/fsutil.go
+++ b/util/fsutil/fsutil.go
@@ -116,7 +116,8 @@ func GetMIMEType(filesystem fs.FS, file string) (contentType string, size int64,
 
 // DetectContentType by sniffing the first 512 bytes of the given reader using `http.DetectContentType`.
 //
-// If the detected content type is `"application/octet-stream"` or `"text/plain"`, this function will attempt to
+// If the detected content type is `"application/octet-stream"`, `"text/plain"`, `"text/xml"` or
+// `"application/xml"`, this function will attempt to
 // find a more precise one using `fsutil.DetectContentTypeByExtension`.
 // The header parameter is retained (e.g: `charset=utf-8`).
 //
@@ -138,7 +139,7 @@ func DetectContentType(r io.Reader, fileName string) (string, error) {
 	}
 
 	contentType := http.DetectContentType(buffer)
-	if strings.HasPrefix(contentType, "application/octet-stream") || strings.HasPrefix(contentType, "text/plain") {
+	if strings.HasPrefix(contentType, "application/octet-stream") || strings.HasPrefix(contentType, "text/plain") || strings.HasPrefix(contentType, "text/xml") || strings.HasPrefix(contentType, "application/xml") {
 		contentType = detectContentTypeByExtension(fileName, contentType)
 	}
 	return contentType, nil
@@ -148,7 +149,7 @@ func detectContentTypeByExtension(fileName, contentType string) string {
 	for ext, t := range contentTypeByExtension {
 		if strings.HasSuffix(fileName, ext) {
 			tmp := t
-			if i := strings.Index(contentType, ";"); i != -1 {
+			if i := strings.Index(contentType, ";"); i != -1 && t != "image/svg+xml" {
 				tmp = t + contentType[i:] // Keep the "charset" arguments
 			}
 			contentType = tmp

--- a/util/fsutil/fsutil.go
+++ b/util/fsutil/fsutil.go
@@ -1,6 +1,7 @@
 package fsutil
 
 import (
+	"bytes"
 	"io"
 	"io/fs"
 	"net/http"
@@ -149,28 +150,13 @@ func DetectContentType(r io.Reader, fileName string) (string, error) {
 }
 
 func hasSVGSignature(buffer []byte) bool {
-	start := -1
-	for i, b := range buffer {
-		if b == '<' {
-			start = i
-			break
-		}
-	}
+	start := bytes.IndexRune(buffer, '<')
 	if start == -1 {
 		return false
 	}
 
-	raw := buffer[start:]
-	normalized := make([]byte, 0, len(raw))
-	for _, b := range raw {
-		if b != 0 {
-			normalized = append(normalized, b)
-		}
-	}
-
-	content := strings.TrimSpace(strings.ToLower(string(normalized)))
-
-	// Skip possible comments
+	content := strings.TrimSpace(strings.ToLower(string(buffer[start:])))
+	// Skip optional XML tag and possible comments
 	for {
 		if strings.HasPrefix(content, "<?xml") {
 			end := strings.Index(content, "?>")
@@ -195,10 +181,13 @@ func hasSVGSignature(buffer []byte) bool {
 }
 
 func detectContentTypeByExtension(fileName, contentType string) string {
+	if fileName == "" {
+		return contentType
+	}
 	for ext, t := range contentTypeByExtension {
 		if strings.HasSuffix(fileName, ext) {
 			tmp := t
-			if i := strings.Index(contentType, ";"); i != -1 && t != "image/svg+xml" {
+			if i := strings.Index(contentType, ";"); i != -1 {
 				tmp = t + contentType[i:] // Keep the "charset" arguments
 			}
 			contentType = tmp

--- a/util/fsutil/fsutil.go
+++ b/util/fsutil/fsutil.go
@@ -116,9 +116,10 @@ func GetMIMEType(filesystem fs.FS, file string) (contentType string, size int64,
 
 // DetectContentType by sniffing the first 512 bytes of the given reader using `http.DetectContentType`.
 //
-// If the detected content type is `"application/octet-stream"`, `"text/plain"`, `"text/xml"` or
-// `"application/xml"`, this function will attempt to
+// If the detected content type is `"application/octet-stream"` or `"text/plain"`, this function will attempt to
 // find a more precise one using `fsutil.DetectContentTypeByExtension`.
+// If the detected content type is `"text/xml"` or `"application/xml"`, this function promotes it to
+// `"image/svg+xml"` only if the content signature indicates SVG.
 // The header parameter is retained (e.g: `charset=utf-8`).
 //
 // If there is no error, this function always returns a valid MIME type. If it cannot determine a more specific one,
@@ -139,10 +140,41 @@ func DetectContentType(r io.Reader, fileName string) (string, error) {
 	}
 
 	contentType := http.DetectContentType(buffer)
-	if strings.HasPrefix(contentType, "application/octet-stream") || strings.HasPrefix(contentType, "text/plain") || strings.HasPrefix(contentType, "text/xml") || strings.HasPrefix(contentType, "application/xml") {
+	if strings.HasPrefix(contentType, "application/octet-stream") || strings.HasPrefix(contentType, "text/plain") {
 		contentType = detectContentTypeByExtension(fileName, contentType)
+	} else if (strings.HasPrefix(contentType, "text/xml") || strings.HasPrefix(contentType, "application/xml")) && hasSVGSignature(buffer) {
+		contentType = "image/svg+xml"
 	}
 	return contentType, nil
+}
+
+func hasSVGSignature(buffer []byte) bool {
+	content := strings.TrimSpace(strings.ToLower(string(buffer)))
+	if strings.HasPrefix(content, "\ufeff") {
+		content = strings.TrimSpace(strings.TrimPrefix(content, "\ufeff"))
+	}
+
+	for {
+		if strings.HasPrefix(content, "<?xml") {
+			end := strings.Index(content, "?>")
+			if end == -1 {
+				break
+			}
+			content = strings.TrimSpace(content[end+2:])
+			continue
+		}
+		if strings.HasPrefix(content, "<!--") {
+			end := strings.Index(content, "-->")
+			if end == -1 {
+				break
+			}
+			content = strings.TrimSpace(content[end+3:])
+			continue
+		}
+		break
+	}
+
+	return strings.HasPrefix(content, "<svg")
 }
 
 func detectContentTypeByExtension(fileName, contentType string) string {

--- a/util/fsutil/fsutil.go
+++ b/util/fsutil/fsutil.go
@@ -150,8 +150,8 @@ func DetectContentType(r io.Reader, fileName string) (string, error) {
 
 func hasSVGSignature(buffer []byte) bool {
 	content := strings.TrimSpace(strings.ToLower(string(buffer)))
-	if strings.HasPrefix(content, "\ufeff") {
-		content = strings.TrimSpace(strings.TrimPrefix(content, "\ufeff"))
+	if after, ok := strings.CutPrefix(content, "\ufeff"); ok {
+		content = strings.TrimSpace(after)
 	}
 
 	for {

--- a/util/fsutil/fsutil.go
+++ b/util/fsutil/fsutil.go
@@ -117,7 +117,7 @@ func GetMIMEType(filesystem fs.FS, file string) (contentType string, size int64,
 // DetectContentType by sniffing the first 512 bytes of the given reader using `http.DetectContentType`.
 //
 // If the detected content type is `"application/octet-stream"` or `"text/plain"`, this function will attempt to
-// find a more precise one using `fsutil.DetectContentTypeByExtension`.
+// find a more precise one using `fsutil.DetectContentTypeByExtension`, unless `fileName` is empty.
 // If the detected content type is `"text/xml"` or `"application/xml"`, this function promotes it to
 // `"image/svg+xml"` only if the content signature indicates SVG.
 // The header parameter is retained (e.g: `charset=utf-8`).

--- a/util/fsutil/fsutil_test.go
+++ b/util/fsutil/fsutil_test.go
@@ -245,6 +245,11 @@ func TestDetectContentType(t *testing.T) {
 			wantMIME: "image/svg+xml",
 		},
 		{
+			fileName: "script.js",
+			buf:      []byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?><root></root>"),
+			wantMIME: "text/xml; charset=utf-8",
+		},
+		{
 			fileName: "eof",
 			buf:      []byte{},
 			wantErr:  true,
@@ -316,6 +321,41 @@ func TestDetectContentTypeByExtension(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
 			assert.Equal(t, c.want, detectContentTypeByExtension(c.fileName, c.contentType))
+		})
+	}
+}
+
+func TestHasSVGSignature(t *testing.T) {
+	cases := []struct {
+		desc string
+		buf  []byte
+		want bool
+	}{
+		{
+			desc: "direct_svg",
+			buf:  []byte("<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>"),
+			want: true,
+		},
+		{
+			desc: "svg_with_prolog",
+			buf:  []byte("<?xml version=\"1.0\"?><svg></svg>"),
+			want: true,
+		},
+		{
+			desc: "svg_with_comment",
+			buf:  []byte("<?xml version=\"1.0\"?><!--comment--><svg></svg>"),
+			want: true,
+		},
+		{
+			desc: "xml_not_svg",
+			buf:  []byte("<?xml version=\"1.0\"?><root></root>"),
+			want: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			assert.Equal(t, c.want, hasSVGSignature(c.buf))
 		})
 	}
 }
@@ -455,6 +495,48 @@ func TestParseMultipartFiles(t *testing.T) {
 		}
 		assert.Equal(t, expected, files)
 		assert.NoError(t, err)
+	})
+
+	t.Run("xml_content_with_js_extension", func(t *testing.T) {
+		filePath := toAbsolutePath("util/fsutil/test.js")
+		err := os.WriteFile(filePath, []byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?><root></root>"), 0644)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			deleteFile(filePath)
+		})
+
+		form := createTestForm("util/fsutil/test.js")
+		files, err := ParseMultipartFiles(form.File["file"])
+
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+		assert.Equal(t, "text/xml; charset=utf-8", files[0].MIMEType)
+	})
+
+	t.Run("declared_content_type_separate_from_detected_mime", func(t *testing.T) {
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+
+		headers := textproto.MIMEHeader{}
+		headers.Set("Content-Disposition", `form-data; name="file"; filename="custom.js"`)
+		headers.Set("Content-Type", "application/javascript")
+
+		part, err := writer.CreatePart(headers)
+		require.NoError(t, err)
+		_, err = part.Write([]byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?><root></root>"))
+		require.NoError(t, err)
+		require.NoError(t, writer.Close())
+
+		reader := multipart.NewReader(body, writer.Boundary())
+		form, err := reader.ReadForm(math.MaxInt64 - 1)
+		require.NoError(t, err)
+
+		files, err := ParseMultipartFiles(form.File["file"])
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+
+		assert.Equal(t, "application/javascript", files[0].Header.Header.Get("Content-Type"))
+		assert.Equal(t, "text/xml; charset=utf-8", files[0].MIMEType)
 	})
 
 	t.Run("empty_file", func(t *testing.T) {

--- a/util/fsutil/fsutil_test.go
+++ b/util/fsutil/fsutil_test.go
@@ -287,6 +287,12 @@ func TestDetectContentTypeByExtension(t *testing.T) {
 			fileName:    "test.xyz",
 		},
 		{
+			desc:        "empty_filename",
+			want:        "unknown",
+			contentType: "unknown",
+			fileName:    "",
+		},
+		{
 			desc:        "unknown_with_params",
 			want:        "unknown; charset=utf-8",
 			contentType: "unknown; charset=utf-8",
@@ -312,7 +318,7 @@ func TestDetectContentTypeByExtension(t *testing.T) {
 		},
 		{
 			desc:        "utf8_svg",
-			want:        "image/svg+xml",
+			want:        "image/svg+xml; charset=utf-8",
 			contentType: "text/xml; charset=utf-8",
 			fileName:    "image.svg",
 		},

--- a/util/fsutil/fsutil_test.go
+++ b/util/fsutil/fsutil_test.go
@@ -240,6 +240,11 @@ func TestDetectContentType(t *testing.T) {
 			wantMIME: "text/javascript",
 		},
 		{
+			fileName: "image.svg",
+			buf:      []byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?><svg xmlns=\"http://www.w3.org/2000/svg\"></svg>"),
+			wantMIME: "image/svg+xml",
+		},
+		{
 			fileName: "eof",
 			buf:      []byte{},
 			wantErr:  true,
@@ -299,6 +304,12 @@ func TestDetectContentTypeByExtension(t *testing.T) {
 			want:        "text/css; charset=utf-8",
 			contentType: "text/plain; charset=utf-8",
 			fileName:    "test.css",
+		},
+		{
+			desc:        "utf8_svg",
+			want:        "image/svg+xml",
+			contentType: "text/xml; charset=utf-8",
+			fileName:    "image.svg",
 		},
 	}
 
@@ -419,6 +430,27 @@ func TestParseMultipartFiles(t *testing.T) {
 			{
 				Header:   form.File["file"][0],
 				MIMEType: "image/png",
+			},
+		}
+		assert.Equal(t, expected, files)
+		assert.NoError(t, err)
+	})
+
+	t.Run("svg", func(t *testing.T) {
+		svgPath := toAbsolutePath("util/fsutil/test.svg")
+		err := os.WriteFile(svgPath, []byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?><svg xmlns=\"http://www.w3.org/2000/svg\"></svg>"), 0644)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			deleteFile(svgPath)
+		})
+
+		form := createTestForm("util/fsutil/test.svg")
+		files, err := ParseMultipartFiles(form.File["file"])
+
+		expected := []File{
+			{
+				Header:   form.File["file"][0],
+				MIMEType: "image/svg+xml",
 			},
 		}
 		assert.Equal(t, expected, files)


### PR DESCRIPTION
## References

**Issue(s):** #xxx <!-- List all related issues here, use keywords if necessary: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->  
**Discussion:** #yyy <!-- If the PR is associated with a Github discussion, reference it here --> 

## Description
The MIME type of an SVG file should be image/svg+xml, otherwise, the front-end cannot render the image based on the MIME type.
<!-- Make a clear and detailed description of your changes, with the added benefits and motivations. -->

<!-- If your pull request is functional (new utilities or middleware for example), **include some usage examples**. -->

### Possible drawbacks

<!-- Describe the possible drawbacks and caveats of your changes here. If there are none, you can remove this section. -->

