### PR TITLE
Fix duplicate path join in OS filesystem utility

### DIFF
--- a/util/fsutil/osfs/osfs.go
+++ b/util/fsutil/osfs/osfs.go
@@ -72,7 +72,7 @@ func (*FS) Getwd() (string, error) {
 // FileExists returns true if the file at the given path exists and is readable.
 // Returns false if the given file is a directory.
 func (f *FS) FileExists(name string) bool {
-	if stats, err := f.Stat(path.Join(f.dir, name)); err == nil {
+	if stats, err := f.Stat(name); err == nil {
 		return !stats.IsDir()
 	}
 	return false
@@ -80,7 +80,7 @@ func (f *FS) FileExists(name string) bool {
 
 // IsDirectory returns true if the file at the given path exists, is a directory and is readable.
 func (f *FS) IsDirectory(name string) bool {
-	if stats, err := f.Stat(path.Join(f.dir, name)); err == nil {
+	if stats, err := f.Stat(name); err == nil {
 		return stats.IsDir()
 	}
 	return false

--- a/util/fsutil/osfs/osfs_test.go
+++ b/util/fsutil/osfs/osfs_test.go
@@ -99,11 +99,25 @@ func TestOSFS(t *testing.T) {
 		assert.False(t, fs.FileExists("resources/notafile.txt"))
 	})
 
+	t.Run("FileExistsWithBaseDir", func(t *testing.T) {
+		fs := New("resources")
+		assert.True(t, fs.FileExists("test_file.txt"))
+		assert.False(t, fs.FileExists("lang"))
+		assert.False(t, fs.FileExists("notafile.txt"))
+	})
+
 	t.Run("IsDirectory", func(t *testing.T) {
 		fs := &FS{}
 		assert.False(t, fs.IsDirectory("resources/test_file.txt"))
 		assert.True(t, fs.IsDirectory("resources"))
 		assert.False(t, fs.IsDirectory("resources/notadir"))
+	})
+
+	t.Run("IsDirectoryWithBaseDir", func(t *testing.T) {
+		fs := New("resources")
+		assert.False(t, fs.IsDirectory("test_file.txt"))
+		assert.True(t, fs.IsDirectory("lang"))
+		assert.False(t, fs.IsDirectory("notadir"))
 	})
 
 	t.Run("Mkdir", func(t *testing.T) {


### PR DESCRIPTION
## References

**Issue(s):** N/A  
**Discussion:** N/A

## Description

Fix `osfs.FS.FileExists` and `osfs.FS.IsDirectory` when a base directory is configured with `New(...)`.

Previously, both methods called `path.Join(f.dir, name)` before delegating to `f.Stat(name)`. Since `Stat` already resolves the given path relative to the filesystem base directory, the base path was effectively joined twice. This caused lookups such as `New("resources").FileExists("test_file.txt")` and `New("resources").IsDirectory("lang")` to fail unexpectedly.

This PR removes the duplicated `path.Join` in both methods and adds regression tests covering `FileExists` and `IsDirectory` with a configured base directory.

### Usage example

```go
fs := osfs.New("resources")

exists := fs.FileExists("test_file.txt") // true
isDir := fs.IsDirectory("lang")          // true
```

### Possible drawbacks

This change slightly alters the behavior of `FileExists` and `IsDirectory` for callers relying on the previous incorrect path resolution. However, the new behavior is consistent with the rest of the filesystem abstraction and with how `Stat` already handles base directories.