### PR TITLE
fix(auth): return 401 on unknown user in basic authenticator

### DIFF
--- a/auth/basic.go
+++ b/auth/basic.go
@@ -68,6 +68,10 @@ func (a *BasicAuthenticator[T]) Authenticate(request *goyave.Request) (*T, error
 		panic(errorutil.New(err))
 	}
 
+	if notFound {
+		return nil, fmt.Errorf("%s", request.Lang.Get("auth.invalid-credentials"))
+	}
+
 	t := reflect.Indirect(reflect.ValueOf(user))
 	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
@@ -77,7 +81,7 @@ func (a *BasicAuthenticator[T]) Authenticate(request *goyave.Request) (*T, error
 		panic(errorutil.Errorf("could not find valid field/column %q in type %T", a.PasswordField, user))
 	}
 
-	if notFound || bcrypt.CompareHashAndPassword([]byte(pass.String()), []byte(password)) != nil {
+	if bcrypt.CompareHashAndPassword([]byte(pass.String()), []byte(password)) != nil {
 		return nil, fmt.Errorf("%s", request.Lang.Get("auth.invalid-credentials"))
 	}
 

--- a/auth/basic_test.go
+++ b/auth/basic_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 	"goyave.dev/goyave/v5"
 	"goyave.dev/goyave/v5/config"
 	"goyave.dev/goyave/v5/slog"
@@ -61,6 +62,26 @@ func TestBasicAuthenticator(t *testing.T) {
 
 		request := server.NewTestRequest(http.MethodGet, "/protected", nil)
 		request.Request().SetBasicAuth(user.Email, "wrong password")
+		request.Route = &goyave.Route{Meta: map[string]any{MetaAuth: true}}
+		resp := server.TestMiddleware(authenticator, request, func(response *goyave.Response, _ *goyave.Request) {
+			assert.Fail(t, "middleware passed despite failed authentication")
+			response.Status(http.StatusOK)
+		})
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		body, err := testutil.ReadJSONBody[map[string]string](resp.Body)
+		assert.NoError(t, resp.Body.Close())
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"error": server.Lang.GetDefault().Get("auth.invalid-credentials")}, body)
+		assert.Equal(t, `Basic realm="Authorization required", charset="UTF-8"`, resp.Header.Get("WWW-Authenticate"))
+	})
+
+	t.Run("not_found", func(t *testing.T) {
+		server, user := prepareAuthenticatorTest(t)
+		mockUserService := &MockUserService[TestUser]{err: gorm.ErrRecordNotFound}
+		authenticator := Middleware(NewBasicAuthenticator(mockUserService, "Password"))
+
+		request := server.NewTestRequest(http.MethodGet, "/protected", nil)
+		request.Request().SetBasicAuth(user.Email, "secret")
 		request.Route = &goyave.Route{Meta: map[string]any{MetaAuth: true}}
 		resp := server.TestMiddleware(authenticator, request, func(response *goyave.Response, _ *goyave.Request) {
 			assert.Fail(t, "middleware passed despite failed authentication")


### PR DESCRIPTION
Reflect-based password field extraction ran before the record-not-found check, so a nil user (gorm.ErrRecordNotFound) caused a reflect panic instead of returning a localized invalid-credentials error. Return early when the user is not found and add a regression test.

## References

no

## Description

## Problem
`BasicAuthenticator.Authenticate` extracted the password field via
reflection before checking whether `FindByUsername` returned
`gorm.ErrRecordNotFound`. When the user does not exist, the returned
`user` is nil, so `reflect.Indirect(reflect.ValueOf(user))` yields a zero
`Value` and `FieldByName` panics with:

    reflect: call of reflect.Value.FieldByName on zero Value

The panic is recovered by the recovery middleware and turned into a
`500 Internal Server Error` instead of the expected, localized
`401 auth.invalid-credentials`. With `app.debug=true` this can also leak
internal error details to the client.

## Changes
- Return the localised `auth.invalid-credentials` error early when the
  user is not found, before any reflection takes place.
- Add a `not_found` regression test asserting a `401` response and the
  `WWW-Authenticate` header.

## Behaviour
Wrong username now returns `401 Unauthorized` (previously `500`).

### Possible drawbacks

no

