### PR TITLE
test(fsutil): stop asserting Go-version-dependent json error text

### DIFF
--- a/util/fsutil/fsutil_test.go
+++ b/util/fsutil/fsutil_test.go
@@ -444,7 +444,11 @@ func TestMarshalFile(t *testing.T) {
 
 		_, err := typeutil.Convert[*testDTO](data)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "cannot unmarshal number into Go struct field testDTO.files of type []fsutil.File")
+		// The error message format depends on the Go version: it names the
+		// struct field either "testDTO.files" or ".files". Only assert on
+		// the stable parts.
+		assert.Contains(t, err.Error(), "cannot unmarshal number into Go struct field")
+		assert.Contains(t, err.Error(), "[]fsutil.File")
 	})
 
 	t.Run("unmarshal_nocache", func(t *testing.T) {


### PR DESCRIPTION
The encoding/json unmarshal error messages changed across Go versions ("testDTO.files" became ".files"), making the exact assertion fail on newer toolchains. Assert only on the stable parts of the message.

## References

no

## Description

## Problem
`TestMarshalFile/unmarshal_err` asserted the exact `encoding/json`
unmarshal message including the concrete type token:

    cannot unmarshal number into Go struct field testDTO.files of type []fsutil.File

Newer Go toolchains (1.26/1.27) elide the named type and emit
`.files` instead, which makes the full test suite fail on those versions
(e.g. `go test ./...` fails under Go 1.27.0).

## Changes
Assert only on the stable fragments of the message (`cannot unmarshal number into Go struct field` and `[]fsutil.File`), keeping the intent of the test while being independent of Go's error-message formatting.

### Possible drawbacks

no

