### PR TITLE
httputil: fix quality value parsing in ParseMultiValuesHeader

### DIFF
--- a/lang/lang_test.go
+++ b/lang/lang_test.go
@@ -170,6 +170,7 @@ func (suite *LangTestSuite) TestDetectLanguage() {
 	suite.Equal(l.languages["fr-FR"], l.DetectLanguage("fr-FR, en-US"))
 	suite.Equal(l.languages["fr-FR"], l.DetectLanguage("fr, en-US;q=0.9"))
 	suite.Equal(l.languages["en-US"], l.DetectLanguage("en, fr-FR;q=0.9"))
+	suite.Equal(l.languages["fr-FR"], l.DetectLanguage("en-US;q=0.5, fr-FR; q=0.9"))
 	suite.Equal(l.languages["en-US"], l.DetectLanguage("*"))
 	suite.Equal(l.languages["en-US"], l.DetectLanguage("notalang"))
 	suite.Equal(l.languages["en-US"], l.DetectLanguage(""))

--- a/middleware/compress/compress_test.go
+++ b/middleware/compress/compress_test.go
@@ -328,6 +328,16 @@ func TestEncoderPriority(t *testing.T) {
 		},
 		{
 			encoders:       []Encoder{br, zstd, gzip},
+			acceptEncoding: "gzip;q=1, br;q=0.9",
+			want:           gzip,
+		},
+		{
+			encoders:       []Encoder{br, zstd, gzip},
+			acceptEncoding: "gzip; q=0.9, br;q=0.8",
+			want:           gzip,
+		},
+		{
+			encoders:       []Encoder{br, zstd, gzip},
 			acceptEncoding: "",
 			want:           nil,
 		},

--- a/util/httputil/httputil.go
+++ b/util/httputil/httputil.go
@@ -1,7 +1,6 @@
 package httputil
 
 import (
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -14,17 +13,35 @@ type HeaderValue struct {
 	Priority float64
 }
 
-var qualityValueRegex = regexp.MustCompile(`^q=([01]\.[0-9]{1,3})$`)
-
 // ParseMultiValuesHeader parses multi-values HTTP headers, taking the
 // quality values into account. The result is a slice of values sorted
 // according to the order of priority.
+// If the input is empty, returns an empty slice.
 //
-// The input is trimmed. If the input is empty, returns an empty slice.
+// The priority of a value is the value of its "q" parameter, the quality
+// value defined by RFC 9110 section 12.4.2: a number between 0 and 1 with
+// at most three digits after the decimal point. Values without a "q"
+// parameter have a priority of 1, the default given by the RFC. If the
+// quality value cannot be parsed, the priority is 0.
 //
-// See: https://developer.mozilla.org/en-US/docs/Glossary/Quality_values
+// Parameters other than "q" are supported, for example the "charset" of a
+// media type. They are ignored: they don't change the priority, and they are
+// not part of the returned value, which only contains what is located before
+// the first ";".
 //
-// For the following header:
+// The input and each segment are trimmed. This includes the header value, the
+// parameter name and the value of the "q" parameter.
+// "text/html ; q = 0.5" is therefore parsed the same way
+// as "text/html;q=0.5".
+//
+// The "q" parameter name is case-insensitive. "Q=0.5" is accepted.
+//
+// See:
+//
+//   - https://datatracker.ietf.org/doc/html/rfc9110#section-12.4.2
+//   - https://developer.mozilla.org/en-US/docs/Glossary/Quality_values
+//
+// For the following header value:
 //
 //	"text/html,text/*;q=0.5,*/*;q=0.7"
 //
@@ -44,29 +61,13 @@ func ParseMultiValuesHeader(header string) []HeaderValue {
 		if comma == -1 {
 			comma = len(h)
 		}
-		v := h[:comma]
-		val := HeaderValue{}
-		if before, after, ok := strings.Cut(v, ";"); ok {
-			// Parse priority
-			q := after
 
-			sub := qualityValueRegex.FindStringSubmatch(q)
-			priority := 0.0
-			if len(sub) > 1 {
-				if p, err := strconv.ParseFloat(sub[1], 64); err == nil {
-					priority = p
-				}
-			}
-			// Priority set to 0 if the quality value cannot be parsed
-			val.Priority = priority
+		value, params, _ := strings.Cut(h[:comma], ";")
+		values = append(values, HeaderValue{
+			Value:    strings.TrimSpace(value),
+			Priority: parseQuality(params),
+		})
 
-			val.Value = strings.TrimSpace(before)
-		} else {
-			val.Value = strings.TrimSpace(v)
-			val.Priority = 1
-		}
-
-		values = append(values, val)
 		if comma == len(h) {
 			break
 		}
@@ -76,4 +77,41 @@ func ParseMultiValuesHeader(header string) []HeaderValue {
 	sort.Sort(byPriority(values))
 
 	return values
+}
+
+// parseQuality returns the quality value defined by the "q" parameter in the
+// given parameter list. Returns 1 if the list doesn't contain a "q" parameter, as specified
+// by RFC 9110, and 0 if the quality value cannot be parsed.
+func parseQuality(params string) float64 {
+	for param := range strings.SplitSeq(params, ";") {
+		name, value, ok := strings.Cut(param, "=")
+		if !ok || !strings.EqualFold(strings.TrimSpace(name), "q") {
+			continue
+		}
+		q := strings.TrimSpace(value)
+		priority, err := strconv.ParseFloat(q, 64)
+		if err != nil || priority < 0 || priority > 1 || !isQualityValue(q) {
+			return 0
+		}
+		return priority
+	}
+	return 1
+}
+
+// isQualityValue returns true if the given string has the shape of a quality
+// value as defined by RFC 9110 section 12.4.2: digits, at most one decimal
+// point, and at most three digits after that point. strconv.ParseFloat accepts
+// numbers that a quality value cannot contain, such as "1e-2", "+0.5", "0x1p-1"
+// and "NaN", so the characters are checked here as well.
+func isQualityValue(q string) bool {
+	dot := strings.IndexByte(q, '.')
+	if dot >= 0 && len(q)-dot-1 > 3 {
+		return false
+	}
+	for i, c := range q {
+		if i != dot && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
 }

--- a/util/httputil/httputil_test.go
+++ b/util/httputil/httputil_test.go
@@ -7,49 +7,164 @@ import (
 )
 
 func TestParseMultiValuesHeader(t *testing.T) {
-	expected := []HeaderValue{
-		{Value: "text/html", Priority: 0.8},
-		{Value: "text/*", Priority: 0.8},
-		{Value: "*/*", Priority: 0.8},
+	cases := []struct {
+		desc   string
+		header string
+		want   []HeaderValue
+	}{
+		{
+			desc:   "equal_quality_values",
+			header: "text/html;q=0.8,text/*;q=0.8,*/*;q=0.8",
+			want: []HeaderValue{
+				{Value: "text/html", Priority: 0.8},
+				{Value: "text/*", Priority: 0.8},
+				{Value: "*/*", Priority: 0.8},
+			},
+		},
+		{
+			desc:   "equal_quality_values_reverse_order",
+			header: "*/*;q=0.8,text/*;q=0.8,text/html;q=0.8",
+			want: []HeaderValue{
+				{Value: "text/html", Priority: 0.8},
+				{Value: "text/*", Priority: 0.8},
+				{Value: "*/*", Priority: 0.8},
+			},
+		},
+		{
+			desc:   "default_priority",
+			header: "text/html,text/*;q=0.5,*/*;q=0.7",
+			want: []HeaderValue{
+				{Value: "text/html", Priority: 1},
+				{Value: "*/*", Priority: 0.7},
+				{Value: "text/*", Priority: 0.5},
+			},
+		},
+		{
+			desc:   "whitespace_around_values",
+			header: "fr , fr-FR;q=0.8, en-US ;q=0.5, *;q=0.3, en-*;q=0.3, en;q=0.3",
+			want: []HeaderValue{
+				{Value: "fr", Priority: 1},
+				{Value: "fr-FR", Priority: 0.8},
+				{Value: "en-US", Priority: 0.5},
+				{Value: "en-*", Priority: 0.3},
+				{Value: "en", Priority: 0.3},
+				{Value: "*", Priority: 0.3},
+			},
+		},
+		{
+			desc:   "single_value",
+			header: "fr",
+			want:   []HeaderValue{{Value: "fr", Priority: 1}},
+		},
+		{
+			desc:   "single_value_with_quality_value",
+			header: "fr;q=0.3",
+			want:   []HeaderValue{{Value: "fr", Priority: 0.3}},
+		},
+		{
+			desc:   "empty",
+			header: "",
+			want:   []HeaderValue{},
+		},
+		{
+			desc:   "whitespace_only",
+			header: "   ",
+			want:   []HeaderValue{},
+		},
+		{
+			desc:   "whitespace_before_quality_value",
+			header: "gzip; q=0.9, br;q=0.8",
+			want:   []HeaderValue{{Value: "gzip", Priority: 0.9}, {Value: "br", Priority: 0.8}},
+		},
+		{
+			desc:   "whitespace_around_quality_value",
+			header: "gzip;q= 0.9, br;q=0.8 , bz;q = 0.7 ",
+			want: []HeaderValue{
+				{Value: "gzip", Priority: 0.9},
+				{Value: "br", Priority: 0.8},
+				{Value: "bz", Priority: 0.7},
+			},
+		},
+		{
+			desc:   "integer_quality_value",
+			header: "gzip;q=1, br;q=0.9",
+			want:   []HeaderValue{{Value: "gzip", Priority: 1}, {Value: "br", Priority: 0.9}},
+		},
+		{
+			desc:   "zero_quality_value",
+			header: "gzip;q=0, br;q=0.1",
+			want:   []HeaderValue{{Value: "br", Priority: 0.1}, {Value: "gzip", Priority: 0}},
+		},
+		{
+			desc:   "quality_value_after_another_parameter",
+			header: "text/html;charset=utf-8;q=0.9, text/plain;q=0.5",
+			want:   []HeaderValue{{Value: "text/html", Priority: 0.9}, {Value: "text/plain", Priority: 0.5}},
+		},
+		{
+			desc:   "no_quality_value_parameter",
+			header: "text/html;charset=utf-8",
+			want:   []HeaderValue{{Value: "text/html", Priority: 1}},
+		},
+		{
+			desc:   "uppercase_parameter_name",
+			header: "gzip;Q=0.5, br;q=0.1",
+			want:   []HeaderValue{{Value: "gzip", Priority: 0.5}, {Value: "br", Priority: 0.1}},
+		},
+		{
+			desc:   "empty_parameter_list",
+			header: "text/html;",
+			want:   []HeaderValue{{Value: "text/html", Priority: 1}},
+		},
+		{
+			desc:   "empty_parameter_list_two_values",
+			header: "text/html;,application/json",
+			want:   []HeaderValue{{Value: "text/html", Priority: 1}, {Value: "application/json", Priority: 1}},
+		},
+		{
+			desc:   "not_a_number",
+			header: "gzip;q=abc, br;q=0.1",
+			want:   []HeaderValue{{Value: "br", Priority: 0.1}, {Value: "gzip", Priority: 0}},
+		},
+		{
+			desc:   "out_of_range",
+			header: "gzip;q=2, br;q=0.1",
+			want:   []HeaderValue{{Value: "br", Priority: 0.1}, {Value: "gzip", Priority: 0}},
+		},
+		{
+			desc:   "negative_quality_value",
+			header: "gzip;q=-0.5, br;q=0.1",
+			want:   []HeaderValue{{Value: "br", Priority: 0.1}, {Value: "gzip", Priority: 0}},
+		},
+		{
+			desc:   "scientific_notation",
+			header: "gzip;q=1e-2, br;q=0.1",
+			want:   []HeaderValue{{Value: "br", Priority: 0.1}, {Value: "gzip", Priority: 0}},
+		},
+		{
+			desc:   "NaN",
+			header: "gzip;q=NaN, br;q=0.1",
+			want:   []HeaderValue{{Value: "br", Priority: 0.1}, {Value: "gzip", Priority: 0}},
+		},
+		{
+			desc:   "plus_sign",
+			header: "gzip;q=+0.5, br;q=0.1",
+			want:   []HeaderValue{{Value: "br", Priority: 0.1}, {Value: "gzip", Priority: 0}},
+		},
+		{
+			desc:   "two_dots",
+			header: "gzip;q=0.5.5, br;q=0.1",
+			want:   []HeaderValue{{Value: "br", Priority: 0.1}, {Value: "gzip", Priority: 0}},
+		},
+		{
+			desc:   "too_many_decimals",
+			header: "gzip;q=0.55555, br;q=0.1",
+			want:   []HeaderValue{{Value: "br", Priority: 0.1}, {Value: "gzip", Priority: 0}},
+		},
 	}
-	result := ParseMultiValuesHeader("text/html;q=0.8,text/*;q=0.8,*/*;q=0.8")
-	assert.Equal(t, expected, result)
 
-	result = ParseMultiValuesHeader("*/*;q=0.8,text/*;q=0.8,text/html;q=0.8")
-	assert.Equal(t, expected, result)
-
-	expected = []HeaderValue{
-		{Value: "text/html", Priority: 1},
-		{Value: "*/*", Priority: 0.7},
-		{Value: "text/*", Priority: 0.5},
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			assert.Equal(t, c.want, ParseMultiValuesHeader(c.header))
+		})
 	}
-	result = ParseMultiValuesHeader("text/html,text/*;q=0.5,*/*;q=0.7")
-	assert.Equal(t, expected, result)
-
-	expected = []HeaderValue{
-		{Value: "fr", Priority: 1},
-		{Value: "fr-FR", Priority: 0.8},
-		{Value: "en-US", Priority: 0.5},
-		{Value: "en-*", Priority: 0.3},
-		{Value: "en", Priority: 0.3},
-		{Value: "*", Priority: 0.3},
-	}
-	result = ParseMultiValuesHeader("fr , fr-FR;q=0.8, en-US ;q=0.5, *;q=0.3, en-*;q=0.3, en;q=0.3")
-	assert.Equal(t, expected, result)
-
-	expected = []HeaderValue{{Value: "fr", Priority: 1}}
-	result = ParseMultiValuesHeader("fr")
-	assert.Equal(t, expected, result)
-
-	expected = []HeaderValue{{Value: "fr", Priority: 0.3}}
-	result = ParseMultiValuesHeader("fr;q=0.3")
-	assert.Equal(t, expected, result)
-
-	expected = []HeaderValue{}
-	result = ParseMultiValuesHeader("")
-	assert.Equal(t, expected, result)
-
-	expected = []HeaderValue{}
-	result = ParseMultiValuesHeader("   ")
-	assert.Equal(t, expected, result)
 }


### PR DESCRIPTION
## References

**Issue(s):** N/A  
**Discussion:** N/A

## Description

`ParseMultiValuesHeader` matched everything located after the first `;` in a header value against `^q=([01]\.[0-9]{1,3})$` (`util/httputil/httputil.go:17`, used at line 53). When that regex did not match, the priority fell back to `0`, so the value sorted last instead of first. Three shapes that RFC 9110 allows do not match it:

- optional whitespace is allowed after the `;`, e.g. `gzip; q=0.9`
- a quality value may have no fraction, e.g. `gzip;q=1` and `gzip;q=0`
- the `q` parameter is not necessarily the first parameter, e.g. `text/html;charset=utf-8;q=0.9`

Both callers of the function ended up with the client's preference backwards. `Accept-Encoding: gzip;q=1, br;q=0.9` made `compress.Middleware.getEncoder` return `br`, and `Accept-Language: en-US;q=0.5, fr-FR; q=0.9` made `lang.Languages.DetectLanguage` return `en-US`.

The fix walks the parameter list and reads the `q` parameter out of it instead of matching the list as a whole, comparing the parameter name case insensitively as RFC 9110 requires, and the quality value itself is checked without a regex: `strconv.ParseFloat` parses it, then anything outside `0` to `1`, anything that is not made of digits and a single decimal point, and anything with more than three digits after that point is rejected, so the integer forms `q=1` and `q=0` are accepted. A value with no `q` parameter gets a priority of 1, which is the RFC 9110 default and already what a value with no parameters at all got.

The new cases in `util/httputil/httputil_test.go`, the two new `TestEncoderPriority` cases and the new `DetectLanguage` assertion all fail on `master` and pass with the change. `go test -race -coverpkg=./... ./...` passes on the whole module and `golangci-lint run` (v2.13.1, repo config) reports 0 issues. `BenchmarkParseMultiValuesHeader` goes from 4 allocs/op to 2 allocs/op, since scanning the parameters no longer builds a submatch slice.

### Possible drawbacks

A value that carries parameters but no `q`, such as `text/html;charset=utf-8`, now has a priority of 1 instead of 0, so it can outrank values it used to sort behind. That is the RFC 9110 default and it matches how a value with no parameters is already handled, but it is a behaviour change for anyone parsing an `Accept` header that has media type parameters.

